### PR TITLE
misc bugfixes

### DIFF
--- a/lib/cli-api/_b2cServicesCreate.js
+++ b/lib/cli-api/_b2cServicesCreate.js
@@ -35,6 +35,7 @@ module.exports = environmentDef => new Promise(async (resolve, reject) => {
         const filePath = path.join(targetFolderPath, fileName);
         const templatePath = path.join(config.get('paths.source.b2c.meta-templates').toString(), fileName);
         let templateFileAsString = fs.readFileSync(templatePath, 'utf8');
+        let logPrefixLength = 9;
         let allServiceString = '';
         let allServiceProfileString = '';
         let allServiceCredentialString = '';
@@ -54,6 +55,15 @@ module.exports = environmentDef => new Promise(async (resolve, reject) => {
             let serviceTemplateString = `${perSiteServiceTemplateFileAsString}`;
             // Use a regex to replace the site ID as it appears multiple times within the template file
             serviceTemplateString = serviceTemplateString.replace(/{{B2C_SITEID}}/gm, siteId);
+
+            // Use a regex to replace the log prefix site ID, errors after 25 characters
+            let logPrefixSiteId = siteId;
+            if (logPrefixLength + logPrefixSiteId.length > 25) {
+                // remove underscores and dashes and limit site id to first 16 characters
+                logPrefixSiteId = logPrefixSiteId.replace(/[_-]/g, '').substring(0, 16);
+            }
+            serviceTemplateString = serviceTemplateString.replace(/{{B2C_SITEID_LOG_PREFIX}}/gm, logPrefixSiteId);
+
             allServiceString += `\n${serviceTemplateString}`;
 
             // Perform the service profile template

--- a/src/sfcc/_templates/meta-data/service_per_site.xml
+++ b/src/sfcc/_templates/meta-data/service_per_site.xml
@@ -1,7 +1,7 @@
     <service service-id="b2ccrmsync.auth.{{B2C_SITEID}}">
         <service-type>HTTP</service-type>
         <enabled>true</enabled>
-        <log-prefix>bcs_auth_{{B2C_SITEID}}</log-prefix>
+        <log-prefix>bcs_auth_{{B2C_SITEID_LOG_PREFIX}}</log-prefix>
         <comm-log-enabled>true</comm-log-enabled>
         <force-prd-enabled>false</force-prd-enabled>
         <mock-mode-enabled>false</mock-mode-enabled>
@@ -12,7 +12,7 @@
     <service service-id="b2ccrmsync.rest.{{B2C_SITEID}}">
         <service-type>HTTP</service-type>
         <enabled>true</enabled>
-        <log-prefix>bcs_rest_{{B2C_SITEID}}</log-prefix>
+        <log-prefix>bcs_rest_{{B2C_SITEID_LOG_PREFIX}}</log-prefix>
         <comm-log-enabled>true</comm-log-enabled>
         <force-prd-enabled>false</force-prd-enabled>
         <mock-mode-enabled>false</mock-mode-enabled>

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/ServiceMgr.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/ServiceMgr.js
@@ -49,7 +49,7 @@ function getPossibleIDs(id) {
         id + '.' + siteID + '.' + countryID,
         id + '.' + siteID,
         id + '.' + countryID,
-        id,
+        id
     ];
 }
 

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/rest.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/rest.js
@@ -69,7 +69,7 @@ function serviceCallback(model, operation, bypassCache) {
 function getServiceCallback(model, operation, bypassCache) {
     var endpoints = require('../b2ccrmsync.config').endpoints;
     if (!endpoints[model] || !endpoints[model][operation]) {
-        throw new Error(require('dw/util/StringUtils').format('Unknown endpoint for the given model "{0}" and operation "{1}"', mode, operation));
+        throw new Error(require('dw/util/StringUtils').format('Unknown endpoint for the given model "{0}" and operation "{1}"', model, operation));
     }
 
     return serviceCallback(model, operation, bypassCache);

--- a/src/sfdc/person-accounts/main/default/duplicateRules/Contact.B2C_Commerce_Standard_Person_Accounts.duplicateRule-meta.xml
+++ b/src/sfdc/person-accounts/main/default/duplicateRules/Contact.B2C_Commerce_Standard_Person_Accounts.duplicateRule-meta.xml
@@ -5,7 +5,6 @@
     <alertText xsi:nil="true"/>
     <description>... duplicate rule used to resolve B2C Commerce customer records via PersonAccounts.</description>
     <duplicateRuleFilter>
-        <booleanFilter>1 OR (2 AND 3) OR (2 AND 4 AND 5) OR (4 AND 5 AND 6)</booleanFilter>
         <duplicateRuleFilterItems>
             <field>B2C_Customer_ID__c</field>
             <operation>notEqual</operation>


### PR DESCRIPTION
@b2csolutionarchitect - These are just a couple of bug fixes for minor issues that I ran into today, installing crm-sync in a client environment. I think they are pretty self-explanatory. The service prefix adjustment works, but feels a little hacky. Let me know if you would like a cleaner approach. The hard-coded "logPrefixLength" of 9 comes from the fact that log prefix prefix of "bcs_auth_" and "bcs_rest_" both equal 9, which only leaves 16 characters left since SFCC errors when the log prefix is greater than 25.