### PR TITLE
code coverage for #28 (B2CIAGetCustomerProfile) and bugfix

### DIFF
--- a/src/sfdc/force-app/main/default/classes/B2CHttpTestCalloutMockGenerator.cls
+++ b/src/sfdc/force-app/main/default/classes/B2CHttpTestCalloutMockGenerator.cls
@@ -55,6 +55,16 @@ public class B2CHttpTestCalloutMockGenerator implements HttpCalloutMock {
             responseObj = getCustomerListFailureResponse();
         }
 
+        // Next, evaluate if we're testing the get customer profile success scenarios
+        if (this.requestType.equalsIgnoreCase('CustomerDetailsSuccess')) {
+            responseObj = getCustomerDetailsSuccessResponse();
+        }
+
+        // Next, evaluate if we're testing the get customer profile failure scenarios
+        if (this.requestType.equalsIgnoreCase('CustomerDetailsFailure')) {
+            responseObj = getCustomerDetailsFailureResponse();
+        }
+
         // Evaluate if testing customer auth for oobo
         if (this.requestType.equalsIgnoreCase('CustomerAuth')) {
 
@@ -62,14 +72,14 @@ public class B2CHttpTestCalloutMockGenerator implements HttpCalloutMock {
             resCustomerAuth.setHeader('Content-Type', 'application/json');
             resCustomerAuth.setHeader('authorization', 'authorizationtoken');
             resCustomerAuth.setBody('{}');
-    
+
             // Set the status details
             resCustomerAuth.setStatus('OK');
             resCustomerAuth.setStatusCode(200);
-    
+
             // Return the response object
             return resCustomerAuth;
-            
+
         }
 
         if (this.requestType.equalsIgnoreCase('BusinessManager')) {
@@ -80,11 +90,11 @@ public class B2CHttpTestCalloutMockGenerator implements HttpCalloutMock {
         if (this.requestType.equalsIgnoreCase('CustomerListsSites')) {
             responseObj = getCustomerListSuccessResponse();
             responseObj.put(
-                'body', 
+                'body',
                 '{"count":"10","data":[{"id":"id","link":"link","customer_list_link":{"customer_list_id":"customer_list_id","link":"link"},"display_name":{"default":"default"}}]}'
             );
         }
-        
+
 
 
         // Retrieve the default http response
@@ -187,6 +197,102 @@ public class B2CHttpTestCalloutMockGenerator implements HttpCalloutMock {
         // Seed the mock-response details
         responseObj.put('status', 'OK');
         responseObj.put('statusCode', '200');
+        responseObj.put('body', bodyContent);
+
+        // Return the mock response details
+        return responseObj;
+
+    }
+
+    /**
+     * @description Helper function to return the customer response
+     * code and body-content details.  This models the successful retrieval of
+     * a B2C Commerce Customer.
+     *
+     * @return Map<String, String> Returns a map containing the
+     * successful response attributes
+     */
+    public static Map<String, String> getCustomerDetailsSuccessResponse() {
+
+        // Initialize local variables
+        Map<String, String> responseObj;
+        String bodyContent;
+
+        // Build out the success response details
+        bodyContent = '{\n' +
+            '"_v": "20.9",\n' +
+            '"_type": "customer",\n' +
+            '"_resource_state": "495f86a4e72211f02037e58c34903a9dbb242e453ab6cad28b3251447870c415",\n' +
+            '"creation_date": "2021-03-29T17:33:05.000Z",\n' +
+            '"credentials": {\n' +
+            '"_type": "credentials",\n' +
+            '"enabled": true,\n' +
+            '"locked": false,\n' +
+            '"login": "john.doe@salesforce.com"\n' +
+            '},\n' +
+            '"customer_id": "bcRskvba1h30X9CoLJKEMkFgUy",\n' +
+            '"customer_no": "C000000001",\n' +
+            '"email": "john.doe@salesforce.com",\n' +
+            '"first_name": "John",\n' +
+            '"gender": 0,\n' +
+            '"last_login_time": "2021-04-14T16:44:37.616Z",\n' +
+            '"last_modified": "2021-04-14T16:47:29.382Z",\n' +
+            '"last_name": "Doe",\n' +
+            '"last_visit_time": "2021-04-14T16:44:37.616Z",\n' +
+            '"phone_home": "9234567890",\n' +
+            '"previous_login_time": "2021-04-14T16:44:37.616Z",\n' +
+            '"previous_visit_time": "2021-04-14T16:44:37.616Z",\n' +
+            '"c_b2ccrm_accountId": "0012D00000W1hbPQAR",\n' +
+            '"c_b2ccrm_contactId": "0032D00000T48x9QAB",\n' +
+            '"c_b2ccrm_syncStatus": "exported"\n' +
+        '}';
+
+        // Initialize the mock response
+        responseObj = new Map<String, String>();
+
+        // Seed the mock-response details
+        responseObj.put('status', 'OK');
+        responseObj.put('statusCode', '200');
+        responseObj.put('body', bodyContent);
+
+        // Return the mock response details
+        return responseObj;
+
+    }
+
+    /**
+     * @description Helper function to return the customer response
+     * code and body-content details.  This models the failed retrieval of
+     * a B2C Commerce Customer.
+     *
+     * @return Map<String, String> Returns a map containing the
+     * successful response attributes
+     */
+    public static Map<String, String> getCustomerDetailsFailureResponse() {
+
+        // Initialize local variables
+        Map<String, String> responseObj;
+        String bodyContent;
+
+        // Build out the success response details
+        bodyContent = '{\n' +
+            '"_v": "20.9",\n' +
+            '"fault": {\n' +
+            '"arguments": {\n' +
+            '"customerNo": "C0000000099",\n' +
+            '"customerListId": "RefArch"\n' +
+            '},\n' +
+            '"type": "CustomerListCustomerNotFoundException",\n' +
+            '"message": "No customer with number \'C0000000099\' for customer list \'RefArch\' could be found."\n' +
+            '}\n' +
+        '}';
+
+        // Initialize the mock response
+        responseObj = new Map<String, String>();
+
+        // Seed the mock-response details
+        responseObj.put('status', 'ERROR');
+        responseObj.put('statusCode', '404');
         responseObj.put('body', bodyContent);
 
         // Return the mock response details

--- a/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile.cls
+++ b/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile.cls
@@ -5,7 +5,7 @@
  * @description This is a wrapper-class to enable the retrieval of a specific
  * B2C Commerce Site via OCAPI.
 */
-global with sharing class B2CIAGetCustomerProfile {
+public with sharing class B2CIAGetCustomerProfile {
 
     /**
      * @see B2CIAGetAccessTokenResult
@@ -15,7 +15,7 @@ global with sharing class B2CIAGetCustomerProfile {
      * @returns {List<B2CIAGetCustomerProfileResult>} Returns the response object containing the customer details
      */
     @InvocableMethod(Label='B2C: Get Customer Profile' Description='Attempts to retrieve details for a B2C Commerce Customer Profile')
-    global static List<B2CIAGetCustomerProfileResult> getCustomerProfile(List<B2CIAGetCustomerProfileInput> requestArguments) {
+    public static List<B2CIAGetCustomerProfileResult> getCustomerProfile(List<B2CIAGetCustomerProfileInput> requestArguments) {
 
         // Initialize local variables
         JSONParse parsedJSON;
@@ -38,7 +38,7 @@ global with sharing class B2CIAGetCustomerProfile {
             https = new Http();
             res = https.send(req);
 
-            // Initialize the siteResult container
+            // Initialize the customerResult container
             customerProfileResult = new B2CIAGetCustomerProfileResult();
 
             // Seed the CRM and B2C versions of the site identifiers
@@ -57,11 +57,12 @@ global with sharing class B2CIAGetCustomerProfile {
             customerProfileResult.status = res.getStatus();
             customerProfileResult.statusCode = res.getStatusCode();
             customerProfileResult.responseBody = parsedJSON.toStringPretty();
-            customerProfileResult.isError = false;
 
             // Check if the statusCode is found in the response and the response was processed successfully
-            if (customerProfileResult.statusCode != 200) {
+            if (customerProfileResult.statusCode == 200) {
+                customerProfileResult.isError = false;
 
+            } else {
                 // Otherwise, capture the error message
                 customerProfileResult.errorMessage = B2CConstant.Errors_OCAPI_Non200ErrorOccurred;
                 customerProfileResult.isError = true;

--- a/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile_Test.cls
+++ b/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile_Test.cls
@@ -1,0 +1,87 @@
+/**
+ * @author Sandra Golden
+ * @date April 14th, 2021
+ *
+ * @description Test class for B2CIAGetCustomerProfile
+*/
+@IsTest
+private class B2CIAGetCustomerProfile_Test {
+    @IsTest
+    static void testB2CIAGetCustomerProfileSuccess() {
+
+        // Initialize local variables
+        B2CIAGetCustomerProfileResult customerProfileResult = new B2CIAGetCustomerProfileResult();
+        String failureMsg;
+
+        Test.startTest();
+
+        // Set the https mock service call
+        Test.setMock(HttpCalloutMock.class, new B2CHttpTestCalloutMockGenerator('CustomerDetailsSuccess'));
+
+        // issue get customer profile web service call
+        B2CIAGetCustomerProfileInput requestInput = new B2CIAGetCustomerProfileInput();
+        List<B2CIAGetCustomerProfileInput> requestArguments = new List<B2CIAGetCustomerProfileInput>{requestInput};
+        //requestArguments.add(requestInput);
+        List<B2CIAGetCustomerProfileResult> customerProfileResults = B2CIAGetCustomerProfile.getCustomerProfile(requestArguments);
+
+        Test.stopTest();
+
+        if (customerProfileResults.size() > 0) {
+            customerProfileResult = customerProfileResults[0];
+        }
+
+        // Check if the statusCode is found in the response and the response was processed successfully
+        if (customerProfileResult.statusCode == 200) {
+            customerProfileResult.isError = false;
+        } else {
+            customerProfileResult.isError = true;
+
+        }
+
+        // Initialize the failure message to display if no error was caught
+        failureMsg = 'Error: an error was caught; expected no error to be included in the response';
+
+        // Assert that an error was caught and alert the user if none was
+        System.assert(customerProfileResult.isError == false, failureMsg);
+
+    }
+
+    @IsTest
+    static void testB2CIAGetCustomerProfileFailure() {
+
+        // Initialize local variables
+        B2CIAGetCustomerProfileResult customerProfileResult = new B2CIAGetCustomerProfileResult();
+        String failureMsg;
+
+        Test.startTest();
+
+        // Set the https mock service call
+        Test.setMock(HttpCalloutMock.class, new B2CHttpTestCalloutMockGenerator('CustomerDetailsFailure'));
+
+        // issue get customer profile web service call
+        B2CIAGetCustomerProfileInput requestInput = new B2CIAGetCustomerProfileInput();
+        List<B2CIAGetCustomerProfileInput> requestArguments = new List<B2CIAGetCustomerProfileInput>{requestInput};
+        //requestArguments.add(requestInput);
+        List<B2CIAGetCustomerProfileResult> customerProfileResults = B2CIAGetCustomerProfile.getCustomerProfile(requestArguments);
+
+        Test.stopTest();
+
+        if (customerProfileResults.size() > 0) {
+            customerProfileResult = customerProfileResults[0];
+        }
+
+        // Check if the statusCode is found in the response and the response was processed successfully
+        if (customerProfileResult.statusCode == 200) {
+            customerProfileResult.isError = false;
+        } else {
+            customerProfileResult.isError = true;
+        }
+
+        // Initialize the failure message to display if no error was caught
+        failureMsg = 'Error: No error was caught; expected an error code to be included in the response';
+
+        // Assert that an error was caught and alert the user if none was
+        System.assert(customerProfileResult.isError == true, failureMsg);
+
+    }
+}

--- a/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile_Test.cls-meta.xml
+++ b/src/sfdc/force-app/main/default/classes/B2CIAGetCustomerProfile_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
issue #28 - added code coverage for **B2CIAGetCustomerProfile**

The second commit here is a weird one. The B2CCommerce_PlatformEvent_ProcessContactUpdate flow was consistently throwing an error for me after a profile update in B2C. The "B2CIAGETCUSTOMERPROFILE" kept erroring with:

`Error Occurred: An Apex error occurred: System.CalloutException: You have uncommitted work pending. Please commit or rollback before calling out`

I played around with it and narrowed it down to line 67:
`customerProfileResult.isError = true;`

I don't understand the fix here but it was basically to set isError inside the if statement. It makes zero sense. Does Salesforce see the second assignment to isError as a DML statement?