### PR TITLE
#47 ... Remove ConnectedAppID-unfriendly characters from the SiteID before creating the ConnectedApp definitions

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,7 +1,7 @@
 module.exports = {
 
     // Describes the current versionNo of the service-cloud-connector
-    "versionNo": "0.5.0",
+    "versionNo": "0.7.5.0",
 
     // Manages debug mode for the CLI application
     "debugMode": true,
@@ -100,6 +100,18 @@ module.exports = {
             "cli",
             "json"
         ]
+
+    },
+
+    // Define the regular expressions used to govern the siteId / connectedAppId
+    "connectedAppIdRegEx": {
+
+        // Describe the individual regExes used to clean the siteId
+        "whiteSpace": /\s/g,
+        "dashes": /-/g,
+        "doubleUnderscore": /_+/g,
+        "nonAlphaNumeric": /[^\w_]+/g,
+        "alphaOnly": /[a-zA-Z]/g
 
     },
 

--- a/lib/cli-api/_common/_cleanSiteIdForConnectedApp.js
+++ b/lib/cli-api/_common/_cleanSiteIdForConnectedApp.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Initialize constants
+const config = require('config');
+
+/**
+ * @function _cleanSiteIdForConnectedApp
+ * @description Helper function to take a siteId and clean-up so that it can be included
+ * in the corresponding salesforcePlatform connectedApp ID name.
+ *
+ * @param siteId {String} Represents the siteId that is being incorporated into a connectedApp name
+ * @returns {String} Returns the cleaned-up siteId that is now safe to use in the connectedApp name
+ */
+module.exports = function _cleanSiteIdForConnectedApp(siteId) {
+
+    // Initialize local variables
+    let output,
+        lastCharacter,
+        firstCharacter;
+
+    // First, remove whitespace
+    output = siteId.trim();
+
+    // Next, replace all whitespace found in the site definition
+    output = output.replace(config.get('connectedAppIdRegEx.whiteSpace'), '');
+
+    // Next, replace all dashes with an underscore (to try and maintain some consistency)
+    output = output.replace(config.get('connectedAppIdRegEx.dashes'), '_');
+
+    // Replace double-underscores until none exist
+    output = output.replace(config.get('connectedAppIdRegEx.doubleUnderscore'), '_');
+
+    // Next, remove all non-alpha-numeric non-underscore characters
+    output = output.replace(config.get('connectedAppIdRegEx.nonAlphaNumeric'), '');
+
+    // Next, ensure the siteId doesn't end in an underscore
+    lastCharacter = output.substr((output.length - 1), 1);
+
+    // Was an underscore found as the last character? If so, remove it
+    if (lastCharacter === '_') {
+        output = output.replace(/.$/, '');
+    }
+
+    // Lastly, ensure the siteId begins with a letter
+    firstCharacter = output.substr(0, 1);
+
+    // If the first character is not a letter, replace it and default the firstCharacter with a letter
+    if (!(config.get('connectedAppIdRegEx.alphaOnly')).test(firstCharacter)) {
+        output = output.replace(/^./, 'a');
+    }
+
+    // Return the cleaned-up siteId for the connectedApp
+    return output;
+
+};

--- a/lib/cli-api/_common/index.js
+++ b/lib/cli-api/_common/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     // Include helper functions that support CLI commands
+    cleanSiteIdForConnectedApp: require('./_cleanSiteIdForConnectedApp'),
     createCodeVersionSummary: require('./_createCodeVersionSummary'),
     createRuntimeEnvironment: require('./_createRuntimeEnvironment'),
     createSFTemplateInstance: require('./_createSFTemplateInstance'),

--- a/lib/cli-api/_sfConnectedAppsCreate.js
+++ b/lib/cli-api/_sfConnectedAppsCreate.js
@@ -9,6 +9,7 @@ const path = require('path');
 // Include the helper library to retrieve the environment details
 const b2cSitesVerify = require('./_b2cSitesVerify');
 const createSFTemplateInstance = require('./_common/_createSFTemplateInstance');
+const cleanSiteIdForConnectedApp = require('./_common/_cleanSiteIdForConnectedApp');
 
 /**
  * @private
@@ -60,8 +61,8 @@ module.exports = environmentDef => new Promise(async (resolve, reject) => {
         const templateFileAsString = fs.readFileSync(templatePath, 'utf8');
 
         output.siteResults.success.filter(site => site.status === 200).forEach(site => {
-            // Initialize the connectedApp properties
-            const connectedAppId = `${environmentDef.b2cInstanceName}_${site.siteId}_B2C_Integration_Tools`;
+            // Initialize the connectedApp properties and clean-up the siteId incorporated into the connectedApp identifier
+            const connectedAppId = `${environmentDef.b2cInstanceName}_${cleanSiteIdForConnectedApp(site.siteId)}_B2C_Integration_Tools`;
             const consumerKey = nanoid(128);
             const consumerSecret = nanoid(32);
 

--- a/test/cli/cli-api/_common/cleanSiteIdForConnectedApp.test.js
+++ b/test/cli/cli-api/_common/cleanSiteIdForConnectedApp.test.js
@@ -1,0 +1,125 @@
+// noinspection JSStringConcatenationToES6Template
+
+'use strict';
+
+// Initialize constants
+const assert = require('chai').assert;
+
+// Initialize dependencies
+const cleanSiteIdForConnectedApp = require('../../../../lib/cli-api/_common/_cleanSiteIdForConnectedApp');
+
+describe('Cleaning the SiteId for a ConnectedApp', function () {
+
+    // Default the root siteValue that will be used in tests
+    // noinspection SpellCheckingInspection
+    const siteRootValue = '_01234abcd_';
+    const cleanedSiteRootValue = 'a01234abcd';
+
+    it('removes non alpha-numeric / underscore characters from the siteId', function () {
+
+        // Initialize local variables
+        let siteId,
+            output;
+
+        // Default the siteId used to validate this test
+        siteId = `   !@#$%${siteRootValue})(*   $*`;
+
+        // Create the code-version summary
+        output = cleanSiteIdForConnectedApp(siteId);
+
+        // Validate that the non-alpha numeric characters are removed from the siteId
+        assert.equal(output, cleanedSiteRootValue, '-- expected all non alpha-numeric characters to be removed');
+
+    });
+
+    it('replaces two underscores with a single underscore', function () {
+
+        // Initialize local variables
+        let siteId,
+            output,
+            validationResult;
+
+        // Default the siteId used to validate this test
+        siteId = `__${siteRootValue}`;
+
+        // Create the code-version summary
+        output = cleanSiteIdForConnectedApp(siteId);
+
+        // Search the cleaned siteId for two underscores
+        validationResult = output.indexOf('__');
+
+        // Validate that two underscores no longer exist in the siteId
+        assert.equal(validationResult, -1, '-- two underscores should not be found in the cleaned siteId');
+
+    });
+
+    it('removes trailing underscores from the siteId', function () {
+
+        // Initialize local variables
+        let siteId,
+            output,
+            lastCharacter;
+
+        // Default the siteId used to validate this test
+        siteId = `${siteRootValue}_`;
+
+        // Create the code-version summary
+        output = cleanSiteIdForConnectedApp(siteId);
+
+        // Search the cleaned siteId for two underscores
+        lastCharacter = output.substr(-1);
+
+        // Validate that the last character in the siteId is not an underscore
+        assert.notEqual(lastCharacter, '_', '-- the last character cannot be an underscore');
+
+    });
+
+    it('removes whitespace from the siteId', function () {
+
+        // Initialize local variables
+        let siteId,
+            output,
+            validationResult;
+
+        // Default the siteId used to validate this test
+        siteId = ` ${siteRootValue}   ${siteRootValue}    `;
+
+        // Create the code-version summary
+        output = cleanSiteIdForConnectedApp(siteId);
+
+        // Search the cleaned siteId for two underscores
+        validationResult = output.indexOf(' ');
+
+        // Validate that the generated environment is returned as an object
+        assert.equal(validationResult, -1, '-- whitespace should not be found in the cleaned siteId');
+
+    });
+
+
+    it('replaces non-alpha 1st characters with an alpha character', function () {
+
+        // Initialize local variables
+        let siteId,
+            output,
+            firstCharacter,
+            validationResult;
+
+        // Default the siteId used to validate this test
+        siteId = `0${siteRootValue}`;
+
+        // Create the code-version summary
+        output = cleanSiteIdForConnectedApp(siteId);
+
+        // Lastly, ensure the siteId begins with a letter
+        firstCharacter = output.substr(0, 1);
+
+        // Search the cleaned siteId for two underscores
+        validationResult = (/[a-zA-Z]/).test(firstCharacter);
+
+        // Validate that the generated environment is returned as an object
+        assert.isTrue(validationResult, '-- expected the first character to be a string');
+
+    });
+
+
+});


### PR DESCRIPTION
... see #47 for details.  We now have a function that scrubs the siteId prior to creating the connectedApp and follows the guidance on character limitations within the connectedAppId.  A unit test has also been created that can be used to validate the helperFunction behavior.

```bash
npm run crm-sync:test:single -- "test/cli/cli-api/_common/cleanSiteIdForConnectedApp.test.js"
```

![image](https://user-images.githubusercontent.com/42348993/115778887-48114000-a385-11eb-91ce-b6ad7bf25d2b.png)

... please review the PR -- and I'll merge this in shortly.  Thanks to everyone for their feedback.