### PR TITLE
Fix for when "Total_Updates_From_B2C_Commerce__c" does not exist

### DIFF
--- a/src/sfdc/force-app/main/default/classes/B2CIAProcessCustomerProfile.cls
+++ b/src/sfdc/force-app/main/default/classes/B2CIAProcessCustomerProfile.cls
@@ -70,7 +70,7 @@ public with sharing class B2CIAProcessCustomerProfile extends B2CBaseAttributeAs
                 thisCustomerProfile.put('Last_Platform_Event_Applied_Updates__c', true);
 
                 // Increment the count of updates applied to the specified contact
-                totalContactUpdates = Integer.valueOf(thisCustomerProfile.get('Total_Updates_From_B2C_Commerce__c')) + 1;
+                totalContactUpdates = thisCustomerProfile.get('Total_Updates_From_B2C_Commerce__c') == null ? 1 : Integer.valueOf(thisCustomerProfile.get('Total_Updates_From_B2C_Commerce__c')) + 1;
 
                 // Increase the total updates and flag that this record was updated via a B2C Platform Event
                 thisCustomerProfile.put('Total_Updates_From_B2C_Commerce__c', totalContactUpdates);


### PR DESCRIPTION
Existing contacts, prior to installing crm-sync, do not have a value for "Total_Updates_From_B2C_Commerce__c". This results in the "B2CCommerce_PlatformEvent_ProcessContactUpdate" flow exiting prematurely and no subsequent profile updates are made in SFDC.