### PR TITLE
#41 - Create the B2C Customer within Core at order placement. Only registered orders where the customer is not yet synched, or guest orders trigger a profile sync to core.

### DIFF
--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.process.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.process.js
@@ -10,44 +10,6 @@
 var LOGGER = require('dw/system/Logger').getLogger('int_b2ccrmsync', 'hooks.customer.process');
 
 /**
- * This returns true if the integration with the Salesforce Platform is enabled or false otherwise
- *
- * @return {Boolean}
- */
-function isIntegrationEnabled() {
-    var Site = require('dw/system/Site').getCurrent();
-    var isSyncEnabled = Site.getCustomPreferenceValue('b2ccrm_syncIsEnabled');
-    var isSyncCustomersEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersEnabled');
-    return isSyncEnabled && isSyncCustomersEnabled;
-}
-
-/**
- * Helper method to identify if the SFDC identifiers are present in a given customerProfile.  Evaluates
- * if the ContactID attribute exists, was set, and has an actual value.
- *
- * @param {dw/customer/Profile} profile
- * @return {Boolean}
- */
-function sfdcContactIDIdentifierPresent(profile) {
-
-    // Is the profile empty?
-    if (profile === null || profile === undefined) { return false; }
-
-    // Is the contactId present in the profile?
-    if (!profile.custom.hasOwnProperty('b2ccrm_contactId')) { return false; }
-
-    // Is the contactId value empty or not set?
-    if (profile.custom.b2ccrm_contactId === null || profile.custom.b2ccrm_contactId === undefined) { return false; }
-
-    // Evaluate the length of the SFDC property
-    if (profile.custom.b2ccrm_contactId.valueOf().length === 0) { return false; }
-
-    // If all conditions pass, there's a contactId
-    return true;
-
-}
-
-/**
  * Customer logged-in
  * Ensure the customer sync and logged-in sync are enabled, and the customer has never been synchronized to the Salesforce Core platform
  * And if so, process the customer sync with the Salesforce Core platform
@@ -55,7 +17,7 @@ function sfdcContactIDIdentifierPresent(profile) {
  * @param {dw/customer/Profile} profile
  */
 function customerLoggedIn(profile) {
-    if (!isIntegrationEnabled() || !profile) {
+    if (!require('../util/helpers').isIntegrationEnabled() || !profile) {
         return;
     }
 
@@ -64,7 +26,7 @@ function customerLoggedIn(profile) {
     var Site = require('dw/system/Site').getCurrent();
     var isSyncEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersOnLoginEnabled');
     var isSyncOnceEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersOnLoginOnceEnabled');
-    if (!isSyncEnabled || (isSyncEnabled && isSyncOnceEnabled && sfdcContactIDIdentifierPresent(profile))) {
+    if (!isSyncEnabled || (isSyncEnabled && isSyncOnceEnabled && require('../util/helpers').sfdcContactIDIdentifierPresent(profile))) {
         return;
     }
 
@@ -78,7 +40,7 @@ function customerLoggedIn(profile) {
  * @param {dw/customer/Profile} profile
  */
 function customerCreated(profile) {
-    if (!isIntegrationEnabled() || !profile) {
+    if (!require('../util/helpers').isIntegrationEnabled() || !profile) {
         return;
     }
 
@@ -92,7 +54,7 @@ function customerCreated(profile) {
  * @param {dw/customer/Profile} profile
  */
 function customerUpdated(profile) {
-    if (!isIntegrationEnabled() || !profile) {
+    if (!require('../util/helpers').isIntegrationEnabled() || !profile) {
         return;
     }
 
@@ -107,7 +69,7 @@ function customerUpdated(profile) {
  */
 function handleProcess(profile, action) {
     var ServiceMgr = require('../services/ServiceMgr');
-    var profileModel = new (require('../models/customer'))(profile, 'process');
+    var profileModel = new (require('../models/customer'))(profile);
 
     try {
         // Set the profile status, meaning that we start the export process

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve.js
@@ -10,23 +10,6 @@
 var LOGGER = require('dw/system/Logger').getLogger('int_b2ccrmsync', 'hooks.customer.retrieve');
 
 /**
- * @type {Array}
- */
-var PROFILE_REQUIRED_KEYS = ['Id', 'B2C_Customer_ID__c', 'B2C_CustomerList_ID__c', 'B2C_Customer_No__c', 'Email', 'Lastname'];
-
-/**
- * This returns true if the integration with the Salesforce Platform is enabled or false otherwise
- *
- * @return {Boolean}
- */
-function isIntegrationEnabled() {
-    var Site = require('dw/system/Site').getCurrent();
-    var isSyncEnabled = Site.getCustomPreferenceValue('b2ccrm_syncIsEnabled');
-    var isSyncCustomersEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersEnabled');
-    return isSyncEnabled && isSyncCustomersEnabled;
-}
-
-/**
  * Retrieve the profile within the Salesforce core platform based on the given {profileDetails}
  *
  * @param {dw/customer/Profile|Object} profileDetails The profile details to use while retrieving the customer from the Salesforce Core platform.
@@ -36,16 +19,19 @@ function isIntegrationEnabled() {
  * @return {Object} The response object from the Salesforce Core platform in case the customer has been successfully retrieved, or undefined otherwise
  */
 function customerRetrieve(profileDetails, saveContactIdOnProfile) {
-    if (!isIntegrationEnabled() || !profileDetails) {
+    if (!require('../util/helpers').isIntegrationEnabled() || !profileDetails) {
         return;
     }
 
     saveContactIdOnProfile = saveContactIdOnProfile || false;
     var areDetailsAnInstanceOfProfile = profileDetails instanceof dw.customer.Profile;
+    var PROFILE_REQUIRED_KEYS = require('dw/web/Resource').msg('customer.retrieve.required.fields', 'b2ccrmsync', '').split(',').map(function (key) {
+        return key.trim();
+    });
 
     try {
         var requestBody = undefined;
-        var profileModel = new (require('../models/customer'))(areDetailsAnInstanceOfProfile ? profileDetails : undefined, 'retrieve');
+        var profileModel = new (require('../models/customer'))(areDetailsAnInstanceOfProfile ? profileDetails : undefined);
         if (areDetailsAnInstanceOfProfile) {
             requestBody = profileModel.getRetrieveRequestBody();
         } else {

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.auth.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.auth.js
@@ -13,7 +13,7 @@ function afterPOST(customer, customerAuth) {
     var Status = require('dw/system/Status');
     var Site = require('dw/system/Site');
 
-    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated()) {
+    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated() || !require('dw/system/HookMgr').hasHook('app.customer.loggedIn')) {
         return;
     }
 

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer.js
@@ -12,11 +12,11 @@ var Site = require('dw/system/Site');
  * @param {Object} customerRegistration Describes the post used to register a customer
  */
 function afterPOST(customer, customerRegistration) {
-    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated()) {
+    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated() || !require('dw/system/HookMgr').hasHook('app.customer.created')) {
         return;
     }
 
-    var LOGGER = Logger.getLogger('int_b2ccrmsync', 'hooks.ocapi.shop.auth.afterPOST');
+    var LOGGER = Logger.getLogger('int_b2ccrmsync', 'hooks.ocapi.shop.customer.afterPOST');
     // Call out that we're executing the customer-profile sync
     LOGGER.info('-- B2C-CRM-Sync: Customer Registration: Start: Sync via OCAPI');
     // Invoke the customer-process hook -- and pass-in the created customer-record
@@ -35,11 +35,11 @@ function afterPOST(customer, customerRegistration) {
  * @param {Object} customerRegistration Describes the post used to update the customer profile
  */
 function afterPATCH(customer, customerRegistration) {
-    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated()) {
+    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersViaOCAPI') || !customer.isAuthenticated() || !require('dw/system/HookMgr').hasHook('app.customer.updated')) {
         return;
     }
 
-    var LOGGER = Logger.getLogger('int_b2ccrmsync', 'hooks.ocapi.shop.auth.afterPATCH');
+    var LOGGER = Logger.getLogger('int_b2ccrmsync', 'hooks.ocapi.shop.customer.afterPATCH');
     // Call out that we're executing the customer-profile sync
     LOGGER.info('-- B2C-CRM-Sync: Customer Profile Update: Syncing Customer Profile via OCAPI');
     // Invoke the customer-process hook -- and pass-in the created customer-record

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.order.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.order.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var Logger = require('dw/system/Logger')
+var Status = require('dw/system/Status');
+var Site = require('dw/system/Site');
+
+/**
+ * @function afterPOST
+ * @description This hook is used to synchronize customer with the Salesforce Platform at order placement
+ * triggered by OCAPI / headless interactions
+ * @param {Object} order Represents the order being placed
+ */
+function afterPOST(order) {
+    if (!Site.getCurrent().getCustomPreferenceValue('b2ccrm_syncCustomersFromOrdersViaOCAPI') || !require('dw/system/HookMgr').hasHook('app.order.created')) {
+        return;
+    }
+
+    var LOGGER = Logger.getLogger('int_b2ccrmsync', 'hooks.ocapi.shop.order.afterPOST');
+    // Call out that we're executing the customer-profile sync
+    LOGGER.info('-- B2C-CRM-Sync: Order Placement: Start: Sync via OCAPI');
+    // Invoke the customer-process hook -- and pass-in the created customer-record
+    require('dw/system/HookMgr').callHook('app.order.created', 'created', order);
+    // Call out that we're done executing the customer-profile sync
+    LOGGER.info('-- B2C-CRM-Sync: Order Placement: Stop: Sync via OCAPI');
+    // Return an ok-status (authorizing the creation)
+    return new Status(Status.OK);
+}
+
+module.exports.afterPOST = afterPOST;

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/order.process.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/order.process.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * @module hooks/order.process
+ */
+
+/**
+ * @type {dw/system/Logger}
+ */
+var LOGGER = require('dw/system/Logger').getLogger('int_b2ccrmsync', 'hooks.order.process');
+
+/**
+ * Order created
+ * Ensure the customer sync is enabled, and if so, process the customer sync with the Salesforce platform from the given order
+ *
+ * @param {dw/order/Order} order
+ */
+function orderCreated(order) {
+    if (!require('../util/helpers').isIntegrationEnabled() || !order) {
+        return;
+    }
+
+    // Ensure the order sync is also enabled
+    // We sync profiles from order ONLY IF
+    // - Either we enabled sync from all orders, the current order is a registered one, and the profile tied to the order has not been synched yet
+    // - Either we enabled sync for guest orders, and the order is a guest one
+    var Site = require('dw/system/Site').getCurrent();
+    var isSyncEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersFromOrdersEnabled');
+    var isSyncOnlyGuestEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled');
+    if (!isSyncEnabled || (isSyncEnabled && (isSyncOnlyGuestEnabled && order.getCustomer().getProfile())) && require('../util/helpers').sfdcContactIDIdentifierPresent(order.getCustomer().getProfile())) {
+        return;
+    }
+
+    handleProcess(order, 'order create');
+}
+
+/**
+ * This method will send the given profile based on the given {order} details to Salesforce Core through REST API
+ *
+ * @param {dw/order/Order} order
+ * @param {String} action The action that triggered the process (createn)
+ */
+function handleProcess(order, action) {
+    var ServiceMgr = require('../services/ServiceMgr');
+    var model = order.getCustomer().getProfile() ? new (require('../models/customer'))(order.getCustomer().getProfile()) : new (require('../models/order'))(order);
+
+    try {
+        // Set the profile status, meaning that we start the export process
+        model.updateStatus('not_exported');
+        var requestBody = model.getProcessRequestBody();
+        LOGGER.info('Exporting the customer profile to Salesforce core from order "{0}". Here is the request body: {1}', order.getOrderNo(), requestBody);
+        var result = ServiceMgr.callRestService('customer', 'process', requestBody);
+
+        // Error while calling the service
+        // The service did not returned a 20x response
+        if (result.status !== 'OK') {
+            model.updateStatus('failed');
+            model.updateSyncResponseText(require('dw/util/StringUtils').format('Status {0} ({1}): {2}', result.error, result.msg, result.errorMessage));
+            LOGGER.error('Error occurred while exporting customer profile from order "{0}": {1}({2}): {3}', order.getOrderNo(), result.status, result.msg, result.errorMessage);
+            return;
+        }
+
+        // The flow always return multiple values, but we only get the first one
+        var resultObject = result.object[0];
+
+        // The service returned a 20x response, but with an error in the response body
+        if (resultObject.isSuccess === false) {
+            var errorsAsString = JSON.stringify(resultObject.errors);
+            model.updateStatus('failed');
+            model.updateSyncResponseText(errorsAsString);
+            LOGGER.error('Error occurred while exporting customer profile from order "{0}": {1}', order.getOrderNo(), errorsAsString);
+            return;
+        }
+
+        // The export succeed
+        LOGGER.info('Successfully exported the customer profile from the order "{0}". Here is the response body: {1}', order.getOrderNo(), JSON.stringify(resultObject));
+        model.updateExternalId(resultObject.outputValues.Contact.AccountId, resultObject.outputValues.Contact.Id);
+        model.updateStatus('exported');
+        model.updateSyncResponseText(require('dw/util/StringUtils').format('Successfully exported to Salesforce Core platform during the "{0}" logic.', action));
+    } catch (e) {
+        model.updateStatus('failed');
+        model.updateSyncResponseText(e.message);
+        LOGGER.error('Error occurred while exporting customer profile from order "{0}": {1}', order.getOrderNo(), e.message);
+    }
+}
+
+module.exports.created = orderCreated;

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/customer.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/customer.js
@@ -5,12 +5,6 @@
  */
 
 /**
- * The SFCC Quota on number of entries within a set-of-string is 200, so ensure we never exceed it
- * @type {Number}
- */
-var MAX_SET_ENTRIES = 200;
-
-/**
  * Customer class
  *
  * @constructor
@@ -24,26 +18,27 @@ function Customer(profile) {
      */
     this.profile = profile;
 
-    if (this.profile) {
-        this.profileRequestObjectRepresentation = {
-            B2C_Customer_ID__c: this.profile.getCustomer().getID(),
-            B2C_Customer_No__c: this.profile.getCustomerNo(),
-            FirstName: this.profile.getFirstName(),
-            LastName: this.profile.getLastName(),
-            Email: this.profile.getEmail(),
-            B2C_CustomerList_ID__c: require('dw/customer/CustomerMgr').getSiteCustomerList().getID()
-        };
+    if (!this.profile) {
+        return;
+    }
 
-        // Send the Salesforce Core Account Id in case of update, or null in case of creation
-        if (this.profile.custom.b2ccrm_accountId !== null) {
-            this.profileRequestObjectRepresentation.AccountId = this.profile.custom.b2ccrm_accountId;
-        }
+    this.profileRequestObjectRepresentation = {
+        B2C_Customer_ID__c: this.profile.getCustomer().getID(),
+        B2C_Customer_No__c: this.profile.getCustomerNo(),
+        FirstName: this.profile.getFirstName(),
+        LastName: this.profile.getLastName(),
+        Email: this.profile.getEmail(),
+        B2C_CustomerList_ID__c: require('dw/customer/CustomerMgr').getSiteCustomerList().getID()
+    };
 
-        // Send the Salesforce Core Contact Id in case of update, or null in case of creation
-        if (this.profile.custom.b2ccrm_contactId !== null) {
-            this.profileRequestObjectRepresentation.Id = this.profile.custom.b2ccrm_contactId;
-        }
+    // Send the Salesforce Core Account Id in case of update, or null in case of creation
+    if (this.profile.custom.b2ccrm_accountId !== null) {
+        this.profileRequestObjectRepresentation.AccountId = this.profile.custom.b2ccrm_accountId;
+    }
 
+    // Send the Salesforce Core Contact Id in case of update, or null in case of creation
+    if (this.profile.custom.b2ccrm_contactId !== null) {
+        this.profileRequestObjectRepresentation.Id = this.profile.custom.b2ccrm_contactId;
     }
 }
 
@@ -76,7 +71,7 @@ Customer.prototype = {
      * @returns {String}
      */
     getProcessRequestBody: function () {
-        if (!this.profile) {
+        if (!this.profileRequestObjectRepresentation) {
             return undefined;
         }
 
@@ -138,7 +133,7 @@ Customer.prototype = {
             syncResponseText.push(require('dw/util/StringUtils').format('{0}: {1}', (new Date()).toGMTString(), text));
 
             // In case the number of values is exceeding the quota, remove the oldest entry
-            if (syncResponseText.length >= MAX_SET_ENTRIES) {
+            if (syncResponseText.length >= require('../util/helpers').MAX_SET_ENTRIES) {
                 syncResponseText.shift();
             }
 

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/order.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/order.js
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * @module models/order
+ */
+
+/**
+ * Order class
+ *
+ * @constructor
+ * @alias module:models/order~Order
+ *
+ * @param {dw/order/Order} [order] Order object
+ */
+function Order(order) {
+    /**
+     * @type {dw/order/Order}
+     */
+    this.order = order;
+
+    if (!this.order) {
+        return;
+    }
+
+    this.profileRequestObjectRepresentation = {
+        FirstName: this.order.getBillingAddress().getFirstName(),
+        LastName: this.order.getBillingAddress().getLastName(),
+        Email: this.order.getCustomerEmail(),
+        B2C_CustomerList_ID__c: require('dw/customer/CustomerMgr').getSiteCustomerList().getID()
+    };
+}
+
+/**
+ * @alias module:models/order~Order#prototype
+ */
+Order.prototype = {
+    /**
+     * Builds up the request body for the process REST API operation
+     *
+     * @returns {String}
+     */
+    getProcessRequestBody: function () {
+        if (!this.profileRequestObjectRepresentation) {
+            return undefined;
+        }
+
+        return JSON.stringify({
+            inputs: [{
+                sourceContact: this.profileRequestObjectRepresentation
+            }]
+        });
+    },
+
+    /**
+     * Update the {custom.b2ccrm_syncStatus} attribute with the given {status}
+     *
+     * @param {String} status The status to save on the order
+     */
+    updateStatus: function (status) {
+        if (!this.order) {
+            return;
+        }
+
+        require('dw/system/Transaction').wrap(function () {
+            this.order.custom.b2ccrm_syncStatus = status;
+        }.bind(this));
+    },
+
+    /**
+     * Update the {custom.b2ccrm_accountId} and {custom.b2ccrm_contactId} attribute with the given {accountID} and {contactID}
+     *
+     * @param {String} accountID The Salesforce Core account ID to save on the order
+     * @param {String} contactID The Salesforce Core contact ID to save on the order
+     */
+    updateExternalId: function (accountID, contactID) {
+        if (!this.order) {
+            return;
+        }
+
+        require('dw/system/Transaction').wrap(function () {
+            if (accountID) {
+                this.order.custom.b2ccrm_accountId = accountID;
+            }
+            if (contactID) {
+                this.order.custom.b2ccrm_contactId = contactID;
+            }
+        }.bind(this));
+    },
+
+    /**
+     * Update the {custom.b2ccrm_syncResponseText} attribute with the given {text}
+     *
+     * @param {String} text The text to save within the sync-response-text set-of-string on the order
+     */
+    updateSyncResponseText: function (text) {
+        if (!this.order) {
+            return;
+        }
+
+        require('dw/system/Transaction').wrap(function () {
+            var syncResponseText = (this.order.custom.b2ccrm_syncResponseText || []).slice(0);
+            syncResponseText.push(require('dw/util/StringUtils').format('{0}: {1}', (new Date()).toGMTString(), text));
+
+            // In case the number of values is exceeding the quota, remove the oldest entry
+            if (syncResponseText.length >= require('../util/helpers').MAX_SET_ENTRIES) {
+                syncResponseText.shift();
+            }
+
+            this.order.custom.b2ccrm_syncResponseText = syncResponseText;
+        }.bind(this));
+    }
+};
+
+module.exports = Order;

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/util/helpers.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/util/helpers.js
@@ -22,4 +22,47 @@ function expandJSON(jsonString, defaultValue) {
     return output;
 }
 
+/**
+ * This returns true if the integration with the Salesforce Platform is enabled or false otherwise
+ *
+ * @return {Boolean}
+ */
+ function isIntegrationEnabled() {
+    var Site = require('dw/system/Site').getCurrent();
+    var isSyncEnabled = Site.getCustomPreferenceValue('b2ccrm_syncIsEnabled');
+    var isSyncCustomersEnabled = Site.getCustomPreferenceValue('b2ccrm_syncCustomersEnabled');
+    return isSyncEnabled && isSyncCustomersEnabled;
+}
+
+/**
+ * Helper method to identify if the SFDC identifiers are present in a given customerProfile.  Evaluates
+ * if the ContactID attribute exists, was set, and has an actual value.
+ *
+ * @param {dw/customer/Profile} profile
+ * @return {Boolean}
+ */
+ function sfdcContactIDIdentifierPresent(profile) {
+    // Is the profile empty?
+    if (profile === null || profile === undefined) { return false; }
+
+    // Is the contactId present in the profile?
+    if (!profile.custom.hasOwnProperty('b2ccrm_contactId')) { return false; }
+
+    // Is the contactId value empty or not set?
+    if (profile.custom.b2ccrm_contactId === null || profile.custom.b2ccrm_contactId === undefined) { return false; }
+
+    // Evaluate the length of the SFDC property
+    if (profile.custom.b2ccrm_contactId.valueOf().length === 0) { return false; }
+
+    // If all conditions pass, there's a contactId
+    return true;
+}
+
 module.exports.expandJSON = expandJSON;
+module.exports.isIntegrationEnabled = isIntegrationEnabled;
+module.exports.sfdcContactIDIdentifierPresent = sfdcContactIDIdentifierPresent;
+/**
+ * The SFCC Quota on number of entries within a set-of-string is 200, so ensure we never exceed it
+ * @type {Number}
+ */
+module.exports.MAX_SET_ENTRIES = 200;

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/templates/resources/b2ccrmsync.properties
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/templates/resources/b2ccrmsync.properties
@@ -1,0 +1,1 @@
+customer.retrieve.required.fields=Id,B2C_Customer_ID__c,B2C_CustomerList_ID__c,B2C_Customer_No__c,Email,Lastname

--- a/src/sfcc/cartridges/int_b2ccrmsync/hooks.json
+++ b/src/sfcc/cartridges/int_b2ccrmsync/hooks.json
@@ -17,6 +17,10 @@
       "script": "~/cartridge/scripts/hooks/customer.retrieve"
     },
     {
+      "name": "app.order.created",
+      "script": "~/cartridge/scripts/hooks/order.process"
+    },
+    {
       "name": "dw.ocapi.shop.auth.afterPOST",
       "script": "~/cartridge/scripts/hooks/ocapi/shop.auth"
     },
@@ -27,6 +31,10 @@
     {
       "name": "dw.ocapi.shop.customer.afterPATCH",
       "script": "~/cartridge/scripts/hooks/ocapi/shop.customer"
+    },
+    {
+      "name": "dw.ocapi.shop.order.afterPOST",
+      "script": "~/cartridge/scripts/hooks/ocapi/shop.order"
     }
   ]
 }

--- a/src/sfcc/cartridges/plugin_b2ccrmsync/cartridge/controllers/Account.js
+++ b/src/sfcc/cartridges/plugin_b2ccrmsync/cartridge/controllers/Account.js
@@ -5,7 +5,7 @@ server.extend(module.superModule);
 
 server.append('Login', function (req, res, next) {
     this.on('route:Complete', function (requ, resp) {
-        if (customer.isAuthenticated()) {
+        if (customer.isAuthenticated() && require('dw/system/HookMgr').hasHook('app.customer.loggedIn')) {
             require('dw/system/HookMgr').callHook('app.customer.loggedIn', 'loggedIn', customer.getProfile());
         }
     });
@@ -14,7 +14,7 @@ server.append('Login', function (req, res, next) {
 
 server.append('SubmitRegistration', function (req, res, next) {
     this.on('route:Complete', function (requ, resp) {
-        if (customer.isAuthenticated()) {
+        if (customer.isAuthenticated() && require('dw/system/HookMgr').hasHook('app.customer.created')) {
             require('dw/system/HookMgr').callHook('app.customer.created', 'created', customer.getProfile());
         }
     });
@@ -23,7 +23,7 @@ server.append('SubmitRegistration', function (req, res, next) {
 
 server.append('SaveProfile', function (req, res, next) {
     this.on('route:Complete', function (requ, resp) {
-        if (customer.isAuthenticated()) {
+        if (customer.isAuthenticated() && require('dw/system/HookMgr').hasHook('app.customer.updated')) {
             require('dw/system/HookMgr').callHook('app.customer.updated', 'updated', customer.getProfile());
         }
     });

--- a/src/sfcc/cartridges/plugin_b2ccrmsync/cartridge/controllers/Order.js
+++ b/src/sfcc/cartridges/plugin_b2ccrmsync/cartridge/controllers/Order.js
@@ -7,8 +7,20 @@ server.append('CreateAccount', function (req, res, next) {
     this.on('route:Complete', function (requ, resp) {
         var viewData = resp.getViewData();
         // If the {newCustomer} object is part of the view data, this means the customer just created it's profile
-        if (customer.isAuthenticated() && viewData.newCustomer) {
+        if (customer.isAuthenticated() && viewData.newCustomer && require('dw/system/HookMgr').hasHook('app.customer.created')) {
             require('dw/system/HookMgr').callHook('app.customer.created', 'created', customer.getProfile());
+        }
+    });
+    next();
+});
+
+server.append('Confirm', function (req, res, next) {
+    this.on('route:Complete', function (requ, resp) {
+        var viewData = resp.getViewData();
+        if (viewData.order && require('dw/system/HookMgr').hasHook('app.order.created')) {
+            // Retrieve again the order as the "order" property from the viewData is the model, which is not holding all the required data
+            var order = require('dw/order/OrderMgr').getOrder(viewData.order.orderNumber);
+            require('dw/system/HookMgr').callHook('app.order.created', 'created', order);
         }
     });
     next();

--- a/src/sfcc/site-template/meta/system-objecttype-extensions.xml
+++ b/src/sfcc/site-template/meta/system-objecttype-extensions.xml
@@ -29,6 +29,64 @@
         </group-definitions>
     </type-extension>
 
+    <type-extension type-id="Order">
+        <custom-attribute-definitions>
+            <attribute-definition attribute-id="b2ccrm_accountId">
+                <display-name xml:lang="x-default">Salesforce Platform Account ID</display-name>
+                <description xml:lang="x-default">Represents the Salesforce Platform Account Id found on a given Customer Record tied to this order.</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_contactId">
+                <display-name xml:lang="x-default">Salesforce Platform Contact ID</display-name>
+                <description xml:lang="x-default">Represents the Salesforce Platform Contact Id found on a given Customer Record tied to this order.</description>
+                <type>string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <min-length>0</min-length>
+            </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_syncStatus">
+                <display-name xml:lang="x-default">Profile Synchronization Status</display-name>
+                <description xml:lang="x-default">Describes the Salesforce B2C CRM Sync Customer Record synchronization status.</description>
+                <type>enum-of-string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <value-definitions>
+                    <value-definition>
+                        <display xml:lang="x-default">Not exported</display>
+                        <value>not_exported</value>
+                    </value-definition>
+                    <value-definition>
+                        <display xml:lang="x-default">Exported</display>
+                        <value>exported</value>
+                    </value-definition>
+                    <value-definition>
+                        <display xml:lang="x-default">Failed to export</display>
+                        <value>failed</value>
+                    </value-definition>
+                </value-definitions>
+            </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_syncResponseText">
+                <display-name xml:lang="x-default">Salesforce Platform Response Text</display-name>
+                <description xml:lang="x-default">Stores the response from B2C-CRM-Sync Customer Record synchronization attempts.</description>
+                <type>set-of-string</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+            </attribute-definition>
+        </custom-attribute-definitions>
+        <group-definitions>
+            <attribute-group group-id="B2CCRMSync">
+                <display-name xml:lang="x-default">B2C-CRM-Sync Properties</display-name>
+                <attribute attribute-id="b2ccrm_accountId"/>
+                <attribute attribute-id="b2ccrm_contactId"/>
+                <attribute attribute-id="b2ccrm_syncStatus"/>
+                <attribute attribute-id="b2ccrm_syncResponseText"/>
+            </attribute-group>
+        </group-definitions>
+    </type-extension>
+
     <type-extension type-id="Profile">
         <custom-attribute-definitions>
             <attribute-definition attribute-id="b2ccrm_accountId">
@@ -129,6 +187,30 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <default-value>false</default-value>
             </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_syncCustomersFromOrdersEnabled">
+                <display-name xml:lang="x-default">Synchronize Customers from order placement?</display-name>
+                <description xml:lang="x-default">When enabled, customer profiles are synchronized with the Salesforce Platform when an order is placed. The Salesforce Platform IDs are then stored on the order.</description>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>false</default-value>
+            </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled">
+                <display-name xml:lang="x-default">Synchronize Customers from guest order placement only?</display-name>
+                <description xml:lang="x-default">When enabled, customer profiles are synchronized with the Salesforce Platform when an order is placed and the order is an anonymous order. The Salesforce Platform IDs are then stored on the order.</description>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>false</default-value>
+            </attribute-definition>
+            <attribute-definition attribute-id="b2ccrm_syncCustomersFromOrdersViaOCAPI">
+                <display-name xml:lang="x-default">Synchronize Customers from order placement via OCAPI?</display-name>
+                <description xml:lang="x-default">When enabled, customer profiles are synchronized with the Salesforce Platform when an order is placed for supported use-cases via OCAPI Hooks (to support Headless Scenarios).</description>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>false</default-value>
+            </attribute-definition>
         </custom-attribute-definitions>
          <group-definitions>
             <attribute-group group-id="B2CCRMSync">
@@ -138,6 +220,9 @@
                 <attribute attribute-id="b2ccrm_syncCustomersOnLoginEnabled"/>
                 <attribute attribute-id="b2ccrm_syncCustomersOnLoginOnceEnabled"/>
                 <attribute attribute-id="b2ccrm_syncCustomersViaOCAPI"/>
+                <attribute attribute-id="b2ccrm_syncCustomersFromOrdersEnabled"/>
+                <attribute attribute-id="b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled"/>
+                <attribute attribute-id="b2ccrm_syncCustomersFromOrdersViaOCAPI"/>
             </attribute-group>
         </group-definitions>
     </type-extension>

--- a/test/b2c/int_b2ccrmsync/scripts/hooks/customer.retrieve.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/hooks/customer.retrieve.test.js
@@ -40,11 +40,14 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         global.request.locale = 'en_US';
         requireStub = {
             'dw/system/Site': require('dw-api-mock/dw/system/Site'),
+            'dw/system/HookMgr': require('dw-api-mock/dw/system/HookMgr'),
+            'dw/web/Resource': require('dw-api-mock/dw/web/Resource'),
             '../models/authToken': sandbox.stub().returns(require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/authToken'))),
             '../services/ServiceMgr': require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/ServiceMgr')),
             '../b2ccrmsync.config': config
         };
         customerRetrieveHook = proxyquire(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve'), requireStub);
+        requireStub['dw/web/Resource'].msg = sandbox.stub().returns('Id,Lastname,CustomerNo');
         profile = new Profile();
         profile.customerNo = '0000001';
         profile.setEmail('jdoe@salesforce.com');
@@ -85,6 +88,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should fail to retrieve the profile if no auth token is found, or an error occur', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             const result = customerRetrieveHook.retrieve();
 
             expect(spy).to.have.not.been.called;
@@ -94,6 +98,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should fail to retrieve the profile if the object given in paremeters does not contain at least one required parameter', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             const result = customerRetrieveHook.retrieve({
                 test: 'value'
             });
@@ -105,6 +110,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should call the rest service to retrieve the profile and fail silently if the service replies an error', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
                 status: 'ERROR',
                 error: 'error',
@@ -118,6 +124,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should call the rest service to retrieve the profile and fail silently if the service OK but contains errors', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             let mockResponse = JSON.parse(JSON.stringify(customerRetrieveMock));
             mockResponse[0].isSuccess = false;
             mockResponse[0].errors = ['error1', 'error2'];
@@ -133,6 +140,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should call the rest service to retrieve the profile and abort because no profile have been found', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             let mockResponse = JSON.parse(JSON.stringify(customerRetrieveMock));
             mockResponse[0].outputValues = undefined;
             requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
@@ -147,6 +155,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should call the rest service to retrieve the profile and update the profile custom attributes accordingly', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
                 status: 'OK',
                 object: customerRetrieveMock
@@ -160,6 +169,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
         it('should call the rest service to retrieve the profile and update the profile custom attributes accordingly when sending an object as parameter', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
                 status: 'OK',
                 object: customerRetrieveMock

--- a/test/b2c/int_b2ccrmsync/scripts/hooks/ocapi/shop.customer.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/hooks/ocapi/shop.customer.test.js
@@ -50,6 +50,16 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer', function 
             expect(spy).to.have.not.been.called;
         });
 
+        it('should not do anything in case the B2C CRM Sync site hook is not present in the codebase', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncCustomersViaOCAPI = false;
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(false);
+            shopCustomerHook.afterPOST(customer);
+
+            expect(spy).to.have.not.been.called;
+        });
+
         it('should not do anything in case the customer is not authenticated', function () {
             const site = require('dw-api-mock/dw/system/Site').getCurrent();
             site.customPreferences.b2ccrm_syncCustomersViaOCAPI = false;
@@ -63,6 +73,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer', function 
         it('should call the HookMgr if the preference is enabled and the customer is authenticated', function () {
             const site = require('dw-api-mock/dw/system/Site').getCurrent();
             site.customPreferences.b2ccrm_syncCustomersViaOCAPI = true;
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
             customer.authenticated = true;
             shopCustomerHook.afterPOST(customer);
@@ -81,6 +92,16 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer', function 
             expect(spy).to.have.not.been.called;
         });
 
+        it('should not do anything in case the B2C CRM Sync site hook is not present in the codebase', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncCustomersViaOCAPI = false;
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(false);
+            shopCustomerHook.afterPATCH(customer);
+
+            expect(spy).to.have.not.been.called;
+        });
+
         it('should not do anything in case the customer is not authenticated', function () {
             const site = require('dw-api-mock/dw/system/Site').getCurrent();
             site.customPreferences.b2ccrm_syncCustomersViaOCAPI = false;
@@ -95,6 +116,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/ocapi/shop.customer', function 
             const site = require('dw-api-mock/dw/system/Site').getCurrent();
             site.customPreferences.b2ccrm_syncCustomersViaOCAPI = true;
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['dw/system/HookMgr'].hasHook = sandbox.stub().returns(true);
             customer.authenticated = true;
             shopCustomerHook.afterPATCH(customer);
 

--- a/test/b2c/int_b2ccrmsync/scripts/hooks/order.process.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/hooks/order.process.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const path = require('path');
+const chai = require('chai');
+const { expect } = chai;
+const sinon = require('sinon');
+const sinonTest = require('sinon-test');
+sinon.test = sinonTest(sinon);
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+const proxyquire = require('proxyquire').noCallThru();
+require('dw-api-mock/demandware-globals');
+const config = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/b2ccrmsync.config'));
+config.services.auth = `http.${config.services.auth}`; // Prepend the 'http' prefix so that the dw-api-mock understands that this is a HTTP Service instance
+config.services.rest = `http.${config.services.rest}`; // Prepend the 'http' prefix so that the dw-api-mock understands that this is a HTTP Service instance
+const customerProcessMock = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.process'));
+
+class Profile {
+    constructor(customerNo, email, firstName, lastName, b2cID, sfContactId, sfAccountId) {
+        this.customerNo = customerNo;
+        this.email = email;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.customer = {
+            ID: b2cID,
+            getID: () => this.customer.ID
+        };
+        this.custom = {
+            b2ccrm_contactId: sfContactId,
+            b2ccrm_accountId: sfAccountId,
+            b2ccrm_syncResponseText: [],
+            b2ccrm_syncStatus: undefined
+        };
+    }
+
+    getEmail() {
+        return this.email;
+    }
+
+    getLastName() {
+        return this.lastName;
+    }
+
+    getFirstName() {
+        return this.lastName;
+    }
+
+    getCustomer() {
+        return this.customer;
+    }
+
+    getCustomerNo() {
+        return this.customerNo;
+    }
+}
+
+class Order {
+    constructor(profile, customerEmail, lastName, firstName, sfContactId, sfAccountId) {
+        this.profile = profile;
+        this.customerEmail = customerEmail;
+        this.billingAddress = {
+            firstName: firstName,
+            lastName: lastName,
+            getFirstName: () => firstName,
+            getLastName: () => lastName
+        };
+        this.customer = {
+            getProfile: () => this.profile
+        };
+        this.custom = {
+            b2ccrm_contactId: sfContactId,
+            b2ccrm_accountId: sfAccountId,
+            b2ccrm_syncResponseText: [],
+            b2ccrm_syncStatus: undefined
+        };
+        this.orderNo = 'orderNo';
+    }
+
+    getOrderNo() {
+        return this.orderNo;
+    }
+
+    getCustomer() {
+        return this.customer;
+    }
+
+    getCustomerEmail() {
+        return this.customerEmail;
+    }
+
+    getBillingAddress() {
+        return this.billingAddress;
+    }
+}
+
+const getEnabledSite = () => {
+    const site = require('dw-api-mock/dw/system/Site').getCurrent();
+    site.customPreferences.b2ccrm_syncIsEnabled = true;
+    site.customPreferences.b2ccrm_syncCustomersEnabled = true;
+    site.customPreferences.b2ccrm_syncCustomersOnLoginEnabled = true;
+    site.customPreferences.b2ccrm_syncCustomersOnLoginOnceEnabled = true;
+    site.customPreferences.b2ccrm_syncCustomersFromOrdersEnabled = true;
+    site.customPreferences.b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled = true;
+    return site;
+};
+
+describe('int_b2ccrmsync/cartridge/scripts/hooks/order.process', function () {
+    let sandbox;
+    let spy;
+    let requireStub;
+    let profile;
+    let order;
+    let orderProcessHook;
+
+    before('setup sandbox', function () {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(function () {
+        global.request.locale = 'en_US';
+        requireStub = {
+            'dw/system/Site': require('dw-api-mock/dw/system/Site'),
+            '../models/authToken': sandbox.stub().returns(require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/authToken'))),
+            '../services/ServiceMgr': require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/ServiceMgr')),
+            '../b2ccrmsync.config': config
+        };
+        orderProcessHook = proxyquire(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/order.process'), requireStub);
+        profile = new Profile('0000001', 'jdoe@salesforce.com', 'Jane', 'Doe', 'aaaaaa', 'bbbbbb', 'cccccc');
+        order = new Order(undefined, 'jdoe@salesforce.com', 'Jane', 'Doe', 'bbbbbb', 'cccccc');
+        spy = sinon.spy(require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/ServiceMgr')), 'callRestService');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        spy && spy.restore();
+    });
+
+    describe('created', function () {
+        it('should not do anything in case no order is sent as parameter', function () {
+            orderProcessHook.created();
+
+            expect(spy).to.have.not.been.called;
+        });
+
+        it('should not do anything in case the B2C CRM Sync site preference is disabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncIsEnabled = false;
+            site.customPreferences.b2ccrm_syncCustomersEnabled = false;
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            orderProcessHook.created(order);
+
+            expect(spy).to.have.not.been.called;
+        });
+
+        it('should not do anything in case the B2C CRM Sync orders site preference is disabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncCustomersFromOrdersEnabled = false;
+            site.customPreferences.b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled = false;
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            orderProcessHook.created(order);
+
+            expect(spy).to.have.not.been.called;
+        });
+
+        it('should not do anything in case the order is tied to a profile that has already been synched', function () {
+            const site = getEnabledSite();
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            order.profile = profile;
+            orderProcessHook.created(order);
+
+            expect(spy).to.have.not.been.called;
+        });
+
+        it('should fail to update the order if no auth token is found, or an error occur', function () {
+            const site = getEnabledSite();
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            orderProcessHook.created(order);
+
+            expect(spy).to.have.been.called;
+            expect(order.custom.b2ccrm_syncStatus).to.be.equal('failed');
+            expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
+        });
+
+        it('should call the rest service to process the profile and fail silently if the service replies an error', function () {
+            const site = getEnabledSite();
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
+                status: 'ERROR',
+                error: 'error',
+                errorMessage: 'message'
+            });
+            orderProcessHook.created(order);
+
+            expect(order.custom.b2ccrm_syncStatus).to.be.equal('failed');
+            expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
+        });
+
+        it('should call the rest service to process the profile and fail silently if the service OK but contains errors', function () {
+            const site = getEnabledSite();
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            let mockResponse = JSON.parse(JSON.stringify(customerProcessMock));
+            mockResponse[0].isSuccess = false;
+            mockResponse[0].errors = ['error1', 'error2'];
+            requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
+                status: 'OK',
+                object: mockResponse
+            });
+            orderProcessHook.created(order);
+
+            expect(order.custom.b2ccrm_syncStatus).to.be.equal('failed');
+            expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
+        });
+
+        it('should call the rest service to process the profile and update the profile custom attributes accordingly', function () {
+            const site = getEnabledSite();
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
+                status: 'OK',
+                object: customerProcessMock
+            });
+            orderProcessHook.created(order);
+
+            expect(order.custom.b2ccrm_syncStatus).to.be.equal('exported');
+            expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
+            expect(order.custom.b2ccrm_accountId).to.be.equal(customerProcessMock[0].outputValues.Contact.AccountId);
+            expect(order.custom.b2ccrm_contactId).to.be.equal(customerProcessMock[0].outputValues.Contact.Id);
+        });
+    });
+});

--- a/test/b2c/int_b2ccrmsync/scripts/models/order.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/models/order.test.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const path = require('path');
+const chai = require('chai');
+const { expect } = chai;
+const sinon = require('sinon');
+const sinonTest = require('sinon-test');
+sinon.test = sinonTest(sinon);
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+require('dw-api-mock/demandware-globals');
+const OrderModel = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/order'));
+
+class Profile {
+    constructor(customerNo, email, firstName, lastName, b2cID, sfContactId, sfAccountId) {
+        this.customerNo = customerNo;
+        this.email = email;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.customer = {
+            ID: b2cID,
+            getID: () => this.customer.ID
+        };
+        this.custom = {
+            b2ccrm_contactId: sfContactId,
+            b2ccrm_accountId: sfAccountId,
+            b2ccrm_syncResponseText: [],
+            b2ccrm_syncStatus: undefined
+        };
+    }
+
+    getEmail() {
+        return this.email;
+    }
+
+    getLastName() {
+        return this.lastName;
+    }
+
+    getFirstName() {
+        return this.firstName;
+    }
+
+    getCustomer() {
+        return this.customer;
+    }
+
+    getCustomerNo() {
+        return this.customerNo;
+    }
+}
+
+class Order {
+    constructor(profile, customerEmail, lastName, firstName, sfContactId, sfAccountId) {
+        this.profile = profile;
+        this.customerEmail = customerEmail;
+        this.billingAddress = {
+            firstName: firstName,
+            lastName: lastName,
+            getFirstName: () => firstName,
+            getLastName: () => lastName
+        };
+        this.customer = {
+            getProfile: () => this.profile
+        };
+        this.custom = {
+            b2ccrm_contactId: sfContactId,
+            b2ccrm_accountId: sfAccountId,
+            b2ccrm_syncResponseText: [],
+            b2ccrm_syncStatus: undefined
+        };
+        this.orderNo = 'orderNo';
+    }
+
+    getOrderNo() {
+        return this.orderNo;
+    }
+
+    getCustomer() {
+        return this.customer;
+    }
+
+    getCustomerEmail() {
+        return this.customerEmail;
+    }
+
+    getBillingAddress() {
+        return this.billingAddress;
+    }
+}
+
+describe('int_b2ccrmsync/cartridge/scripts/models/order', function () {
+    let sandbox;
+    let spy;
+    let profile;
+    let orderObj;
+
+    before('setup sandbox', function () {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(function () {
+        profile = new Profile('0000001', 'jdoe@salesforce.com', 'Jane', 'Doe', 'aaaaaa', 'bbbbbb', 'cccccc');
+        orderObj = new Order(profile, 'jdoe@salesforce.com', 'Jane', 'Doe', 'bbbbbb', 'cccccc');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        spy && spy.restore();
+    });
+
+    describe('getProcessRequestBody', function () {
+        it('should return a stringified body of the order data sent within the model', function () {
+            const order = new OrderModel(orderObj);
+            const result = order.getProcessRequestBody();
+            const parsedResult = JSON.parse(result);
+
+            expect(result).to.not.be.null;
+            expect(result).to.not.be.empty;
+            expect(parsedResult.inputs[0].sourceContact).to.deep.equal({
+                FirstName: orderObj.getBillingAddress().getFirstName(),
+                LastName: orderObj.getBillingAddress().getLastName(),
+                Email: orderObj.getCustomerEmail(),
+                B2C_CustomerList_ID__c: 'ID' // Default ID from the dw-api-mock
+            });
+        });
+
+        it('should return a stringified body of the order data sent within the model, but without accountId nor contactId in case of first attempt', function () {
+            orderObj.custom.b2ccrm_accountId = undefined;
+            orderObj.custom.b2ccrm_contactId = undefined;
+            const order = new OrderModel(orderObj);
+            const result = order.getProcessRequestBody();
+            const parsedResult = JSON.parse(result);
+
+            expect(result).to.not.be.null;
+            expect(result).to.not.be.empty;
+            expect(parsedResult.inputs[0].sourceContact).to.deep.equal({
+                FirstName: orderObj.getBillingAddress().getFirstName(),
+                LastName: orderObj.getBillingAddress().getLastName(),
+                Email: orderObj.getCustomerEmail(),
+                B2C_CustomerList_ID__c: 'ID' // Default ID from the dw-api-mock
+            });
+        });
+
+        it('should return undefined when no order is given to the model', function () {
+            const order = new OrderModel();
+            const result = order.getProcessRequestBody();
+
+            expect(result).to.be.undefined;
+        });
+    });
+
+    describe('updateStatus', function () {
+        it('should save the given data into the order custom attribute', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            order.updateStatus('status');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_syncStatus).to.be.equal('status');
+        });
+
+        it('should not do anything in case no order is sent within the model', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel();
+            order.updateStatus('status');
+
+            expect(spy).to.have.not.been.called;
+        });
+    });
+
+    describe('updateExternalId', function () {
+        it('should save the given data into the order custom attributes', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            order.updateExternalId('accountId', 'contactId');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_accountId).to.be.equal('accountId');
+            expect(orderObj.custom.b2ccrm_contactId).to.be.equal('contactId');
+        });
+
+        it('should only save the account ID into the order custom attribute', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            order.updateExternalId('accountId');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_accountId).to.be.equal('accountId');
+            expect(orderObj.custom.b2ccrm_contactId).to.be.equal(profile.custom.b2ccrm_contactId);
+        });
+
+        it('should only save the contact ID into the order custom attribute', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            order.updateExternalId(undefined, 'contactId');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_accountId).to.be.equal(profile.custom.b2ccrm_accountId);
+            expect(orderObj.custom.b2ccrm_contactId).to.be.equal('contactId');
+        });
+
+        it('should not do anything in case no order is sent within the model', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel();
+            order.updateExternalId('status');
+
+            expect(spy).to.have.not.been.called;
+        });
+    });
+
+    describe('updateSyncResponseText', function () {
+        it('should save response text in the order custom attribute if this is the first time the response text is saved and so the custom attribute is undefined', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            orderObj.custom.b2ccrm_syncResponseText = undefined;
+            const order = new OrderModel(orderObj);
+            order.updateSyncResponseText('response text');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_syncResponseText.length).to.be.equal(1);
+            expect(orderObj.custom.b2ccrm_syncResponseText[0]).to.not.be.undefined;
+        });
+
+        it('should save response text in the order custom attribute if this is the first time the response text is saved', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            order.updateSyncResponseText('response text');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_syncResponseText.length).to.be.equal(1);
+            expect(orderObj.custom.b2ccrm_syncResponseText[0]).to.not.be.undefined;
+        });
+
+        it('should save response text in the order custom attribute, even if we already saved response texts previously', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            orderObj.custom.b2ccrm_syncResponseText = ['previously saved response text'];
+            const order = new OrderModel(orderObj);
+            order.updateSyncResponseText('response text');
+
+            expect(spy).to.have.been.calledOnce;
+            expect(orderObj.custom.b2ccrm_syncResponseText.length).to.be.equal(2);
+            orderObj.custom.b2ccrm_syncResponseText.forEach(value => expect(value).to.not.be.undefined);
+        });
+
+        it('should save response text in the order custom attribute, and remove the first element of the array as the limit is reached', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel(orderObj);
+            for (let i = 0; i < 201; ++i) {
+                order.updateSyncResponseText(`response text ${i}`);
+            }
+
+            expect(spy).to.have.been.called;
+            // Ensure the array size is under the limit of 200
+            expect(orderObj.custom.b2ccrm_syncResponseText.length).to.be.equal(199);
+            orderObj.custom.b2ccrm_syncResponseText.forEach(value => expect(value).to.not.be.undefined);
+        });
+
+        it('should not do anything in case no order is sent within the model', function () {
+            spy = sinon.spy(require('dw-api-mock/dw/system/Transaction'), 'wrap');
+            const order = new OrderModel();
+            order.updateSyncResponseText('response text');
+
+            expect(spy).to.have.not.been.called;
+        });
+    });
+});

--- a/test/b2c/int_b2ccrmsync/scripts/util/helpers.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/util/helpers.test.js
@@ -11,7 +11,9 @@ chai.use(sinonChai);
 const proxyquire = require('proxyquire').noCallThru();
 require('dw-api-mock/demandware-globals');
 
-const requireStub = {};
+const requireStub = {
+    'dw/system/Site': require('dw-api-mock/dw/system/Site')
+};
 const helpers = proxyquire(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/util/helpers'), requireStub);
 
 describe('int_b2ccrmsync/cartridge/scripts/util/helpers', function () {
@@ -84,6 +86,106 @@ describe('int_b2ccrmsync/cartridge/scripts/util/helpers', function () {
 
             expect(newObj).to.not.be.null;
             expect(newObj).to.deep.equal(obj);
+        });
+    });
+
+    describe('isIntegrationEnabled', function () {
+        it('should be enabled if both preferences are enabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncIsEnabled = true;
+            site.customPreferences.b2ccrm_syncCustomersEnabled = true;
+            const isEnabled = helpers.isIntegrationEnabled();
+
+            expect(isEnabled).to.be.true;
+        });
+
+        it('should be disabled if the b2ccrm_syncIsEnabled preference is disabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncIsEnabled = false;
+            site.customPreferences.b2ccrm_syncCustomersEnabled = true;
+            const isEnabled = helpers.isIntegrationEnabled();
+
+            expect(isEnabled).to.not.be.true;
+        });
+
+        it('should be disabled if the b2ccrm_syncCustomersEnabled preference is disabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncIsEnabled = true;
+            site.customPreferences.b2ccrm_syncCustomersEnabled = false;
+            const isEnabled = helpers.isIntegrationEnabled();
+
+            expect(isEnabled).to.not.be.true;
+        });
+
+        it('should be disabled if both preferences are disabled', function () {
+            const site = require('dw-api-mock/dw/system/Site').getCurrent();
+            site.customPreferences.b2ccrm_syncIsEnabled = false;
+            site.customPreferences.b2ccrm_syncCustomersEnabled = false;
+            const isEnabled = helpers.isIntegrationEnabled();
+
+            expect(isEnabled).to.not.be.true;
+        });
+    });
+
+    describe('sfdcContactIDIdentifierPresent', function () {
+        it('should return false if the profile is undefined', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent(undefined);
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return false if the profile is null', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent(null);
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return false if the profile has no b2ccrm_contactId custom property', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent({
+                custom: {}
+            });
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return false if the profile\'s b2ccrm_contactId custom property is undefined', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent({
+                custom: {
+                    b2ccrm_contactId: undefined
+                }
+            });
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return false if the profile\'s b2ccrm_contactId custom property is null', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent({
+                custom: {
+                    b2ccrm_contactId: null
+                }
+            });
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return false if the profile\'s b2ccrm_contactId custom property is an empty string', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent({
+                custom: {
+                    b2ccrm_contactId: ''
+                }
+            });
+
+            expect(hasContactId).to.be.false;
+        });
+
+        it('should return true if the profile\'s b2ccrm_contactId custom property exists', function () {
+            const hasContactId = helpers.sfdcContactIDIdentifierPresent({
+                custom: {
+                    b2ccrm_contactId: 'id'
+                }
+            });
+
+            expect(hasContactId).to.be.true;
         });
     });
 });


### PR DESCRIPTION
Handles the issue #41 .

Covered by UT:
![Screenshot 2021-06-28 at 08 23 54](https://user-images.githubusercontent.com/47380544/123589930-467f5080-d7ea-11eb-8f40-4ebca5dfe089.png)

![Screenshot 2021-06-26 at 18 10 03](https://user-images.githubusercontent.com/47380544/123519157-df5a8280-d6a9-11eb-8857-d81deea9ce3c.png)
