### PR TITLE
Update the retrieve logic to match the updated flow on core side.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ $RECYCLE.BIN/
 # Ignore my test-deployment file
 **DeployTest.*
 .nyc_output
+connectedAppCredentials.json

--- a/lib/cli-interface/_sfScratchOrgBuild.js
+++ b/lib/cli-interface/_sfScratchOrgBuild.js
@@ -137,8 +137,8 @@ module.exports = commandProgram => {
 
                 // Create the certificates folder(s) -- if they do not exist
                 console.log(' -- verifying / creating the certificates directory');
-                await fsLib.verifyAndCreateFolder(config.get('paths.sfdx.certs-root'), true);
-                await fsLib.verifyAndCreateFolder(config.get('paths.sfdx.certs-sfdc'), true);
+                await fsLib.verifyAndCreateFolder(config.get('paths.source.dx.certs-root'), true);
+                await fsLib.verifyAndCreateFolder(config.get('paths.source.dx.certs-sfdc'), true);
 
                 // Create the scratch org
                 console.log(' -- creating the specified scratch org; please standby');

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.process.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.process.js
@@ -107,7 +107,7 @@ function handleProcess(profile, action) {
     try {
         // Set the profile status, meaning that we start the export process
         profileModel.updateStatus('not_exported');
-        var requestBody = profileModel.getProcessRequestBody();
+        var requestBody = profileModel.getRequestBody();
         LOGGER.info('Exporting the customer profile to Salesforce core. Here is the request body: {0}', requestBody);
         var result = ServiceMgr.callRestService('customer', 'process', requestBody);
 

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve.js
@@ -50,14 +50,14 @@ function customerRetrieve(profileDetails, saveContactIdOnProfile) {
         var requestBody;
 
         if (areDetailsAnInstanceOfProfile) {
-            requestBody = profileModel.getRetrieveRequestBody();
+            requestBody = profileModel.getRequestBody();
         } else {
             if (!PROFILE_REQUIRED_KEYS.some(function (key) {
                 return profileDetails[key];
             })) {
                 return;
             }
-            requestBody = profileModel.getRetrieveRequestBody(profileDetails);
+            requestBody = profileModel.getRequestBody(profileDetails);
         }
 
         var ServiceMgr = require('../services/ServiceMgr');
@@ -81,7 +81,7 @@ function customerRetrieve(profileDetails, saveContactIdOnProfile) {
         }
 
         // The service returned a 20x response, but with no match on the given request body
-        if (!resultObject.outputValues || !resultObject.outputValues.ContactListResolved) {
+        if (!resultObject.outputValues || !resultObject.outputValues.ResolutionCount || resultObject.outputValues.ResolutionCount === 0) {
             LOGGER.error('No Salesforce Core record is matching the given request.');
             return;
         }
@@ -92,14 +92,14 @@ function customerRetrieve(profileDetails, saveContactIdOnProfile) {
         // In case the {saveContactIdOnProfile} flag is true and there is a customer authenticated
         // Then save the retrieved contact Id on the currently authenticated customer profile
         if (saveContactIdOnProfile && areDetailsAnInstanceOfProfile) {
-            var accountId = resultObject.outputValues.ContactListResolved[0].AccountId;
-            var contactId = resultObject.outputValues.ContactListResolved[0].Id;
+            var accountId = resultObject.outputValues.Account.Id;
+            var contactId = resultObject.outputValues.Contact.Id;
             profileModel.updateSyncResponseText(require('dw/util/StringUtils').format('Successfully retrieved from Salesforce Platform. Contact ID updated from "{0}" to "{1}"', profileDetails.custom.b2ccrm_contactId, contactId));
             profileModel.updateExternalId(accountId, contactId);
         }
 
         // Return the retrieve customer profile record from the Salesforce Platform
-        return resultObject.outputValues.ContactListResolved[0];
+        return resultObject.outputValues;
     } catch (e) {
         LOGGER.error('Error occurred while retrieving customer profile: {0}', e.message);
     }

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/order.process.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/hooks/order.process.js
@@ -59,7 +59,7 @@ function handleProcess(order, action) {
     try {
         // Set the profile status, meaning that we start the export process
         model.updateStatus('not_exported');
-        var requestBody = model.getProcessRequestBody();
+        var requestBody = model.getRequestBody();
         LOGGER.info('Exporting the customer profile to Salesforce core from order "{0}". Here is the request body: {1}', order.getOrderNo(), requestBody);
         var result = ServiceMgr.callRestService('customer', 'process', requestBody);
 

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/customer.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/customer.js
@@ -4,8 +4,7 @@
  * @object {Class}
  * @typedef Customer This class is used to manage B2C Customer profile and REST API orchestration
  * activities between B2C Commerce and the Salesforce Platform
- * @property {Function} getRetrieveRequestBody Builds up the request body for the retrieve REST API operation
- * @property {Function} getProcessRequestBody Builds up the request body for the retrieve REST API operation
+ * @property {Function} getRequestBody Builds up the request body for the REST API operation
  * @property {Function} updateStatus Save / write the integration status on the profile being interacted with
  * @property {Function} updateExternalId Update the AccountId and ContactId attributes from the Salesforce Platform
  * @property {Function} updateSyncResponseText Audit a given synchronization event with a message and timestamp
@@ -56,37 +55,20 @@ function Customer(profile) {
 }
 
 Customer.prototype = {
-
     /**
      * @memberOf Customer
-     * @function getRetrieveRequestBody
-     * @description Builds up the request body for the retrieve REST API operation
+     * @function getRequestBody
+     * @description Builds up the request body for the REST API operation
      *
      * @param {Object} profileDetails The profile details as raw object, overrides the {profile} from the
      * model in the generated request body if provided
-     * @returns {String} Returns the body used to invoke the B2CContactResolve service
-     */
-    getRetrieveRequestBody: function (profileDetails) {
-        if (!profileDetails && !this.profile) { return undefined; }
-        return JSON.stringify({
-            inputs: [{
-                ContactList: [profileDetails || this.profileRequestObjectRepresentation]
-            }]
-        });
-    },
-
-    /**
-     * @memberOf Customer
-     * @function getProcessRequestBody
-     * @description Builds up the request body for the process REST API operation
      *
-     * @returns {String} Returns the body to be used by the B2CContactProcess serviceRequest
+     * @returns {String} Returns the body to be used by the serviceRequest
      */
-    getProcessRequestBody: function () {
-        if (!this.profileRequestObjectRepresentation) { return undefined; }
+    getRequestBody: function (profileDetails) {
         return JSON.stringify({
             inputs: [{
-                sourceContact: this.profileRequestObjectRepresentation
+                sourceContact: profileDetails || this.profileRequestObjectRepresentation
             }]
         });
     },

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/order.js
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/models/order.js
@@ -8,7 +8,7 @@
  * @object {Class}
  * @typedef Order This class is used to manage B2C Customer profile and REST API orchestration
  * activities between B2C Commerce and the Salesforce Platform when an order is placed
- * @property {Function} getRetrieveRequestBody Builds up the request body for the retrieve REST API operation
+ * @property {Function} getRequestBody Builds up the request body for the REST API operation
  * @property {Function} getProcessRequestBody Builds up the request body for the retrieve REST API operation
  * @property {Function} updateStatus Save / write the integration status on the profile being interacted with
  * @property {Function} updateExternalId Update the AccountId and ContactId attributes from the Salesforce Platform
@@ -46,13 +46,12 @@ function Order(order) {
 }
 
 Order.prototype = {
-
     /**
-     * @description Builds up the request body for the process REST API operation
+     * @description Builds up the request body for the REST API operation
      *
-     * @returns {String} Returns the body used to invoke the B2CContactResolve service
+     * @returns {String} Returns the body used to invoke the service
      */
-    getProcessRequestBody: function () {
+    getRequestBody: function () {
         if (!this.profileRequestObjectRepresentation) { return undefined; }
         return JSON.stringify({
             inputs: [{

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.process.json
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.process.json
@@ -7,7 +7,7 @@
             "Account": {
                 "attributes": {
                     "type": "Account",
-                    "url": "/services/data/v50.0/sobjects/Account/0011j000012gy9mAAA"
+                    "url": "/services/data/v52.0/sobjects/Account/0011j000012gy9mAAA"
                 },
                 "Name": "Account Name Example",
                 "RecordTypeId": "0121j000001meUxAAI",
@@ -19,7 +19,7 @@
             "Contact": {
                 "attributes": {
                     "type": "Contact",
-                    "url": "/services/data/v50.0/sobjects/Contact/0031j00000sOaPYAA0"
+                    "url": "/services/data/v52.0/sobjects/Contact/0031j00000sOaPYAA0"
                 },
                 "Id": "0031j00000sOaPYAA0",
                 "FirstName": "John",

--- a/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.retrieve.json
+++ b/src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.retrieve.json
@@ -1,23 +1,43 @@
-[
-    {
-        "actionName": "B2CContactResolve",
-        "errors": null,
-        "isSuccess": true,
-        "outputValues": {
-            "ContactListResolved": [
-                {
-                    "attributes": {
-                        "type": "Contact",
-                        "url": "/services/data/v50.0/sobjects/Contact/0031j00000sOaTQAA0"
-                    },
-                    "Id": "0031j00000sOaTQAA0",
-                    "LastName": "Doe",
-                    "Email": "jdoe@email.com"
-                }
-            ],
-            "errors": null,
-            "Flow__InterviewStatus": "Finished",
-            "isSuccess": true
-        }
-    }
-]
+[{
+	"actionName": "B2CContactResolve",
+	"errors": null,
+	"isSuccess": true,
+	"outputValues": {
+		"ResolutionCount": 1.0,
+		"Account": {
+			"attributes": {
+				"type": "Account",
+				"url": "/services/data/v52.0/sobjects/Account/0019E00001W1kNpQAJ"
+			},
+			"Id": "0019E00001W1kNpQAJ",
+			"Name": "Account Name Example",
+			"RecordTypeId": "0129E000000pNMFQA2",
+			"AccountSource": "Web",
+			"Type": "Customer - Direct"
+		},
+		"ErrorMessage": null,
+		"Flow__InterviewStatus": "Finished",
+		"Contact": {
+			"attributes": {
+				"type": "Contact",
+				"url": "/services/data/v52.0/sobjects/Contact/0039E00001HarCMQAZ"
+			},
+			"Id": "0039E00001HarCMQAZ",
+			"AccountId": "0019E00001W1kNpQAJ",
+			"B2C_CustomerList__c": "a049E000008enShQAI",
+			"B2C_CustomerList_ID__c": "RefArch",
+			"B2C_Customer_ID__c": "abAtnApePB13xFkkdvOhcR84uW",
+			"B2C_Customer_No__c": "00004001",
+			"FirstName": "John",
+			"LastName": "Doe",
+			"Email": "jdoe@example.com",
+			"B2C_Disable_Integration__c": false,
+			"B2C_Date_Last_Modified__c": "2021-07-13T13:02:49.000+0000",
+			"CreatedDate": "2021-07-13T13:02:48.000+0000",
+			"LastModifiedDate": "2021-07-13T13:02:52.000+0000",
+			"Audit_OCAPI_API_Response__c": false
+		},
+		"ResolvedContacts": null,
+		"isSuccess": true
+	}
+}]

--- a/test/b2c/int_b2ccrmsync/scripts/hooks/customer.retrieve.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/hooks/customer.retrieve.test.js
@@ -13,7 +13,6 @@ require('dw-api-mock/demandware-globals');
 const config = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/b2ccrmsync.config'));
 config.services.auth = `http.${config.services.auth}`; // Prepend the 'http' prefix so that the dw-api-mock understands that this is a HTTP Service instance
 config.services.rest = `http.${config.services.rest}`; // Prepend the 'http' prefix so that the dw-api-mock understands that this is a HTTP Service instance
-const authMock = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/auth'));
 const customerRetrieveMock = require(path.join(process.cwd(), 'src/sfcc/cartridges/int_b2ccrmsync/cartridge/scripts/services/mocks/customer.retrieve'));
 const Profile = require('dw-api-mock/dw/customer/Profile');
 
@@ -164,7 +163,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
             const result = customerRetrieveHook.retrieve(profile, true);
 
             expect(result).to.not.be.undefined;
-            expect(result).to.deep.equal(customerRetrieveMock[0].outputValues.ContactListResolved[0]);
+            expect(result).to.deep.equal(customerRetrieveMock[0].outputValues);
         });
 
         it('should call the rest service to retrieve the profile and update the profile custom attributes accordingly when sending an object as parameter', function () {
@@ -180,7 +179,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/customer.retrieve', function ()
             });
 
             expect(result).to.not.be.undefined;
-            expect(result).to.deep.equal(customerRetrieveMock[0].outputValues.ContactListResolved[0]);
+            expect(result).to.deep.equal(customerRetrieveMock[0].outputValues);
         });
     });
 });

--- a/test/b2c/int_b2ccrmsync/scripts/hooks/order.process.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/hooks/order.process.test.js
@@ -211,7 +211,7 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/order.process', function () {
             expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
         });
 
-        it('should call the rest service to process the profile and update the profile custom attributes accordingly', function () {
+        it('should call the rest service to process the profile and update the order\'s custom attributes accordingly', function () {
             const site = getEnabledSite();
             requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
             requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
@@ -224,6 +224,23 @@ describe('int_b2ccrmsync/cartridge/scripts/hooks/order.process', function () {
             expect(order.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
             expect(order.custom.b2ccrm_accountId).to.be.equal(customerProcessMock[0].outputValues.Contact.AccountId);
             expect(order.custom.b2ccrm_contactId).to.be.equal(customerProcessMock[0].outputValues.Contact.Id);
+        });
+
+        it('should call the rest service to process the profile and update the profile custom attributes accordingly in case the order is not a guest one', function () {
+            order = new Order(profile, 'jdoe@salesforce.com', 'Jane', 'Doe', 'bbbbbb', 'cccccc');
+            const site = getEnabledSite();
+            site.customPreferences.b2ccrm_syncCustomersFromGuestOrdersOnlyEnabled = false;
+            requireStub['dw/system/Site'].getCurrent = sandbox.stub().returns(site);
+            requireStub['../services/ServiceMgr'].callRestService = sandbox.stub().returns({
+                status: 'OK',
+                object: customerProcessMock
+            });
+            orderProcessHook.created(order);
+
+            expect(profile.custom.b2ccrm_syncStatus).to.be.equal('exported');
+            expect(profile.custom.b2ccrm_syncResponseText.length).to.not.be.equal(0);
+            expect(profile.custom.b2ccrm_accountId).to.be.equal(customerProcessMock[0].outputValues.Contact.AccountId);
+            expect(profile.custom.b2ccrm_contactId).to.be.equal(customerProcessMock[0].outputValues.Contact.Id);
         });
     });
 });

--- a/test/b2c/int_b2ccrmsync/scripts/models/customer.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/models/customer.test.js
@@ -68,7 +68,7 @@ describe('int_b2ccrmsync/cartridge/scripts/models/customer', function () {
         spy && spy.restore();
     });
 
-    describe('getRetrieveRequestBody', function () {
+    describe('getRequestBody', function () {
         it('should return a stringified body of the given profil details passed in parameters, when the model does no hold a profile', function () {
             const customer = new CustomerModel();
             const profileData = {
@@ -76,12 +76,12 @@ describe('int_b2ccrmsync/cartridge/scripts/models/customer', function () {
                 LastName: 'Doe',
                 FirstName: 'John'
             };
-            const result = customer.getRetrieveRequestBody(profileData);
+            const result = customer.getRequestBody(profileData);
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
             expect(result).to.not.be.empty;
-            expect(parsedResult.inputs[0].ContactList[0]).to.deep.equal(profileData);
+            expect(parsedResult.inputs[0].sourceContact).to.deep.equal(profileData);
         });
 
         it('should return a stringified body of the given profil details passed in parameters, even if the model holds a profile', function () {
@@ -91,64 +91,17 @@ describe('int_b2ccrmsync/cartridge/scripts/models/customer', function () {
                 LastName: 'Doe',
                 FirstName: 'John'
             };
-            const result = customer.getRetrieveRequestBody(profileData);
+            const result = customer.getRequestBody(profileData);
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
             expect(result).to.not.be.empty;
-            expect(parsedResult.inputs[0].ContactList[0]).to.deep.equal(profileData);
+            expect(parsedResult.inputs[0].sourceContact).to.deep.equal(profileData);
         });
 
         it('should return a stringified body of the profile data sent within the model', function () {
             const customer = new CustomerModel(profile);
-            const result = customer.getRetrieveRequestBody();
-            const parsedResult = JSON.parse(result);
-
-            expect(result).to.not.be.null;
-            expect(result).to.not.be.empty;
-            expect(parsedResult.inputs[0].ContactList[0]).to.deep.equal({
-                AccountId: profile.custom.b2ccrm_accountId,
-                Id: profile.custom.b2ccrm_contactId,
-                B2C_Customer_ID__c: profile.getCustomer().getID(),
-                B2C_Customer_No__c: profile.getCustomerNo(),
-                FirstName: profile.getFirstName(),
-                LastName: profile.getLastName(),
-                Email: profile.getEmail(),
-                B2C_CustomerList_ID__c: 'ID' // Default ID from the dw-api-mock
-            });
-        });
-
-        it('should return a stringified body of the profile data sent within the model, but without a contactId in case of first attempt', function () {
-            profile.custom.b2ccrm_contactId = undefined;
-            const customer = new CustomerModel(profile);
-            const result = customer.getRetrieveRequestBody();
-            const parsedResult = JSON.parse(result);
-
-            expect(result).to.not.be.null;
-            expect(result).to.not.be.empty;
-            expect(parsedResult.inputs[0].ContactList[0]).to.deep.equal({
-                AccountId: profile.custom.b2ccrm_accountId,
-                B2C_Customer_ID__c: profile.getCustomer().getID(),
-                B2C_Customer_No__c: profile.getCustomerNo(),
-                FirstName: profile.getFirstName(),
-                LastName: profile.getLastName(),
-                Email: profile.getEmail(),
-                B2C_CustomerList_ID__c: 'ID' // Default ID from the dw-api-mock
-            });
-        });
-
-        it('should return undefined when no profile is given to the model and no profile details within the method', function () {
-            const customer = new CustomerModel();
-            const result = customer.getRetrieveRequestBody();
-
-            expect(result).to.be.undefined;
-        });
-    });
-
-    describe('getProcessRequestBody', function () {
-        it('should return a stringified body of the profile data sent within the model', function () {
-            const customer = new CustomerModel(profile);
-            const result = customer.getProcessRequestBody();
+            const result = customer.getRequestBody();
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
@@ -169,7 +122,7 @@ describe('int_b2ccrmsync/cartridge/scripts/models/customer', function () {
             profile.custom.b2ccrm_accountId = undefined;
             profile.custom.b2ccrm_contactId = undefined;
             const customer = new CustomerModel(profile);
-            const result = customer.getProcessRequestBody();
+            const result = customer.getRequestBody();
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
@@ -184,11 +137,11 @@ describe('int_b2ccrmsync/cartridge/scripts/models/customer', function () {
             });
         });
 
-        it('should return undefined when no profile is given to the model', function () {
+        it('should return an empty input body when no profile is given to the model', function () {
             const customer = new CustomerModel();
-            const result = customer.getProcessRequestBody();
+            const result = customer.getRequestBody();
 
-            expect(result).to.be.undefined;
+            expect(result).to.equal('{"inputs":[{}]}');
         });
     });
 

--- a/test/b2c/int_b2ccrmsync/scripts/models/order.test.js
+++ b/test/b2c/int_b2ccrmsync/scripts/models/order.test.js
@@ -109,10 +109,10 @@ describe('int_b2ccrmsync/cartridge/scripts/models/order', function () {
         spy && spy.restore();
     });
 
-    describe('getProcessRequestBody', function () {
+    describe('getRequestBody', function () {
         it('should return a stringified body of the order data sent within the model', function () {
             const order = new OrderModel(orderObj);
-            const result = order.getProcessRequestBody();
+            const result = order.getRequestBody();
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
@@ -129,7 +129,7 @@ describe('int_b2ccrmsync/cartridge/scripts/models/order', function () {
             orderObj.custom.b2ccrm_accountId = undefined;
             orderObj.custom.b2ccrm_contactId = undefined;
             const order = new OrderModel(orderObj);
-            const result = order.getProcessRequestBody();
+            const result = order.getRequestBody();
             const parsedResult = JSON.parse(result);
 
             expect(result).to.not.be.null;
@@ -144,7 +144,7 @@ describe('int_b2ccrmsync/cartridge/scripts/models/order', function () {
 
         it('should return undefined when no order is given to the model', function () {
             const order = new OrderModel();
-            const result = order.getProcessRequestBody();
+            const result = order.getRequestBody();
 
             expect(result).to.be.undefined;
         });


### PR DESCRIPTION
Update the customer.retrieve logic from B2C to match the changes made into the Resolve flow on the core side.

Unit tests have been updated too, all 128 B2C tests are passing:
![Screenshot 2021-07-13 at 16 03 26](https://user-images.githubusercontent.com/47380544/125465865-fabde192-dc1a-4a24-b75e-66be46e85e4a.png)
![Screenshot 2021-07-13 at 16 03 40](https://user-images.githubusercontent.com/47380544/125465872-b0b02f9f-0f13-423e-9d98-f445aaf839b7.png)
![Screenshot 2021-07-13 at 16 03 45](https://user-images.githubusercontent.com/47380544/125465880-907fc9f9-079e-469c-b309-09835e02aa9b.png)


Also, UT coverage:
![Screenshot 2021-07-13 at 16 03 04](https://user-images.githubusercontent.com/47380544/125465833-0d34a4f7-c319-4fb8-9a7d-9b8af2e649e9.png)